### PR TITLE
Fix aws us db prefix

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -11,7 +11,7 @@ class Config extends BaseConfig
     private const STACK_DATABASES = [
         'connection.keboola.com' => [
             'db_replica_prefix' => 'AWSUS',
-            'db_prefix' => 'sapi',
+            'db_prefix' => 'SAPI',
             'account' => 'KEBOOLA',
             'region' => 'AWS_US_WEST_2',
         ],


### PR DESCRIPTION
Database 'AWS_US_WEST_2.KEBOOLA."sapi_6231"' does not exist or is not authorized.,

databáze "sapi_6231" neexistuje - jsou tam s prefixem "SAPI_*"

ozkoušeno - https://connection.us-east4.gcp.keboola.com/admin/projects/244/queue/10975739