### PR TITLE
feat: add parallel migration and cross-backend type conversion

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -248,4 +248,9 @@ class Config extends BaseConfig
     {
         return (bool) $this->getValue(['parameters', 'migrateData'], true);
     }
+
+    public function getParallelism(): int
+    {
+        return $this->getIntValue(['parameters', 'parallelism'], 1);
+    }
 }

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -19,6 +19,7 @@ class ConfigDefinition extends BaseConfigDefinition
             ->children()
                 ->enumNode('mode')->values(['sapi', 'database'])->defaultValue('sapi')->end()
                 ->booleanNode('dryRun')->defaultFalse()->end()
+                ->integerNode('parallelism')->defaultValue(1)->min(1)->max(10)->end()
                 ->booleanNode('isSourceByodb')->defaultFalse()->end()
                 ->scalarNode('sourceByodb')->end()
                 ->scalarNode('sourceKbcUrl')->isRequired()->cannotBeEmpty()->end()

--- a/src/StorageModifier.php
+++ b/src/StorageModifier.php
@@ -5,20 +5,26 @@ declare(strict_types=1);
 namespace Keboola\AppProjectMigrateLargeTables;
 
 use Keboola\Csv\CsvFile;
+use Keboola\Datatype\Definition\Bigquery;
+use Keboola\Datatype\Definition\Snowflake;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Exception as StorageApiException;
 use Keboola\StorageApi\Metadata;
 use Keboola\StorageApi\Options\Metadata\TableMetadataUpdateOptions;
 use Keboola\Temp\Temp;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class StorageModifier
 {
     private Temp $tmp;
+    private LoggerInterface $logger;
 
-    public function __construct(readonly Client $client)
+    public function __construct(readonly Client $client, ?LoggerInterface $logger = null)
     {
         $this->tmp = new Temp();
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function createBucket(string $schemaName): void
@@ -59,6 +65,8 @@ class StorageModifier
 
     private function createTypedTable(array $tableInfo): void
     {
+        $sourceBackendType = $tableInfo['bucket']['backend'];
+        $destinationBackendType = $this->getDestinationBucketBackend($tableInfo['bucket']['id']);
         $columns = [];
         foreach ($tableInfo['columns'] as $column) {
             $columns[$column] = [];
@@ -72,18 +80,38 @@ class StorageModifier
                 }
                 $columnMetadata[$metadata['key']] = $metadata['value'];
             }
-
-            $definition = [
-                'type' => $columnMetadata['KBC.datatype.type'],
-                'nullable' => $columnMetadata['KBC.datatype.nullable'] === '1',
-            ];
-            if (isset($columnMetadata['KBC.datatype.length'])) {
-                $definition['length'] = $columnMetadata['KBC.datatype.length'];
+            if ($destinationBackendType !== $sourceBackendType) {
+                $sourceBaseType = $this->getBaseType(
+                    $sourceBackendType,
+                    $columnMetadata['KBC.datatype.type'],
+                );
+                switch ($destinationBackendType) {
+                    case 'snowflake':
+                        $definition = (Snowflake::getDefinitionForBasetype((string) $sourceBaseType))->toArray();
+                        break;
+                    case 'bigquery':
+                        $definition = (Bigquery::getDefinitionForBasetype((string) $sourceBaseType))->toArray();
+                        break;
+                    default:
+                        $this->logger->warning(sprintf(
+                            'Unsupported destination backend type "%s" for cross-backend type conversion',
+                            $destinationBackendType,
+                        ));
+                        continue 2;
+                }
+                $definition['nullable'] = $columnMetadata['KBC.datatype.nullable'] === '1';
+            } else {
+                $definition = [
+                    'type' => $columnMetadata['KBC.datatype.type'],
+                    'nullable' => $columnMetadata['KBC.datatype.nullable'] === '1',
+                ];
+                if (isset($columnMetadata['KBC.datatype.length'])) {
+                    $definition['length'] = $columnMetadata['KBC.datatype.length'];
+                }
+                if (isset($columnMetadata['KBC.datatype.default'])) {
+                    $definition['default'] = $columnMetadata['KBC.datatype.default'];
+                }
             }
-            if (isset($columnMetadata['KBC.datatype.default'])) {
-                $definition['default'] = $columnMetadata['KBC.datatype.default'];
-            }
-
             $columns[$columnName] = [
                 'name' => $columnName,
                 'definition' => $definition,
@@ -167,5 +195,23 @@ class StorageModifier
             ];
         }
         return $result;
+    }
+
+    private function getDestinationBucketBackend(string $bucketId): string
+    {
+        $bucket = $this->client->getBucket($bucketId);
+        return $bucket['backend'];
+    }
+
+    private function getBaseType(string $backend, string $originalType): ?string
+    {
+        switch ($backend) {
+            case 'snowflake':
+                return (new Snowflake($originalType))->getBasetype();
+            case 'bigquery':
+                return (new Bigquery($originalType))->getBasetype();
+            default:
+                return null;
+        }
     }
 }

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -40,6 +40,25 @@ class SapiMigrate implements MigrateInterface
 
     public function migrate(Config $config): void
     {
+        $parallelism = $config->getParallelism();
+        $tablesToMigrate = $this->prepareTablesToMigrate($config);
+        if ($parallelism <= 1) {
+            foreach ($tablesToMigrate as $tableInfo) {
+                $this->migrateTable($tableInfo, $config);
+            }
+        } else {
+            $this->logger->info(sprintf('Migrating tables with parallelism: %d', $parallelism));
+            $this->migrateTablesInParallel($tablesToMigrate, $config, $parallelism);
+        }
+    }
+
+    /**
+     * Prepares tables for migration by validating them and creating buckets/tables as needed.
+     * @return array<array<string, mixed>> Array of table info arrays ready for migration
+     */
+    private function prepareTablesToMigrate(Config $config): array
+    {
+        $tablesToMigrate = [];
         foreach ($config->getMigrateTables() ?: $this->getAllTables() as $tableId) {
             try {
                 $tableInfo = $this->sourceClient->getTable($tableId);
@@ -55,12 +74,10 @@ class SapiMigrate implements MigrateInterface
                 $this->logger->warning(sprintf('Skipping table %s (sys bucket)', $tableInfo['id']));
                 continue;
             }
-
             if ($tableInfo['isAlias']) {
                 $this->logger->warning(sprintf('Skipping table %s (alias)', $tableInfo['id']));
                 continue;
             }
-
             if (!in_array($tableInfo['bucket']['id'], $this->bucketsExist) &&
                 !$this->targetClient->bucketExists($tableInfo['bucket']['id'])) {
                 if ($this->dryRun) {
@@ -68,11 +85,9 @@ class SapiMigrate implements MigrateInterface
                 } else {
                     $this->logger->info(sprintf('Creating bucket %s', $tableInfo['bucket']['id']));
                     $this->bucketsExist[] = $tableInfo['bucket']['id'];
-
                     $this->storageModifier->createBucket($tableInfo['bucket']['id']);
                 }
             }
-
             if (!$this->targetClient->tableExists($tableId)) {
                 if ($this->dryRun) {
                     $this->logger->info(sprintf('[dry-run] Creating table %s', $tableInfo['id']));
@@ -81,9 +96,171 @@ class SapiMigrate implements MigrateInterface
                     $this->storageModifier->createTable($tableInfo);
                 }
             }
-
-            $this->migrateTable($tableInfo, $config);
+            $tablesToMigrate[] = $tableInfo;
         }
+        return $tablesToMigrate;
+    }
+
+    /**
+     * Migrates tables in parallel batches.
+     * @param array<array<string, mixed>> $tablesToMigrate
+     */
+    private function migrateTablesInParallel(array $tablesToMigrate, Config $config, int $parallelism): void
+    {
+        $batches = array_chunk($tablesToMigrate, max(1, $parallelism));
+        foreach ($batches as $batchIndex => $batch) {
+            $this->logger->info(sprintf(
+                'Processing batch %d/%d (%d tables)',
+                $batchIndex + 1,
+                count($batches),
+                count($batch),
+            ));
+            $this->processBatch($batch, $config);
+        }
+    }
+
+    /**
+     * Processes a batch of tables in parallel.
+     * @param array<array<string, mixed>> $batch
+     */
+    private function processBatch(array $batch, Config $config): void
+    {
+        $exportJobs = [];
+        foreach ($batch as $tableInfo) {
+            assert(is_string($tableInfo['id']));
+            $tableId = $tableInfo['id'];
+            $this->logger->info(sprintf('Queueing export for table %s', $tableId));
+            $jobId = $this->sourceClient->queueTableExport($tableId, [
+                'gzip' => true,
+                'includeInternalTimestamp' => $config->preserveTimestamp(),
+            ]);
+            $exportJobs[$tableId] = [
+                'jobId' => $jobId,
+                'tableInfo' => $tableInfo,
+            ];
+        }
+        $exportResults = [];
+        foreach ($exportJobs as $tableId => $jobData) {
+            $this->logger->info(sprintf('Waiting for export job for table %s', $tableId));
+            $job = $this->sourceClient->waitForJob($jobData['jobId']);
+            if ($job === null || $job['status'] !== 'success') {
+                $errorMessage = $job['error']['message'] ?? 'Unknown error';
+                $this->logger->warning(sprintf(
+                    'Export failed for table %s: %s',
+                    $tableId,
+                    $errorMessage,
+                ));
+                continue;
+            }
+            $results = $job['results'];
+            assert(is_array($results) && is_array($results['file']));
+            $file = $results['file'];
+            assert(isset($file['id']) && is_int($file['id']));
+            $fileId = $file['id'];
+            $exportResults[$tableId] = [
+                'tableInfo' => $jobData['tableInfo'],
+                'fileId' => $fileId,
+            ];
+        }
+        $uploadResults = [];
+        foreach ($exportResults as $tableId => $exportData) {
+            $result = $this->downloadAndUpload($exportData['tableInfo'], $exportData['fileId'], $config);
+            if ($result !== null) {
+                $uploadResults[$tableId] = [
+                    'tableInfo' => $exportData['tableInfo'],
+                    'destinationFileId' => $result,
+                ];
+            }
+        }
+        $importJobs = [];
+        foreach ($uploadResults as $tableId => $uploadData) {
+            if ($this->dryRun) {
+                assert(is_string($uploadData['tableInfo']['name']));
+                $tableName = $uploadData['tableInfo']['name'];
+                $this->logger->info(sprintf('[dry-run] Import data to table "%s"', $tableName));
+                continue;
+            }
+            $this->logger->info(sprintf('Queueing import for table %s', $tableId));
+            $jobId = $this->targetClient->queueTableImport(
+                $tableId,
+                [
+                    'name' => $uploadData['tableInfo']['name'],
+                    'dataFileId' => $uploadData['destinationFileId'],
+                    'columns' => $uploadData['tableInfo']['columns'],
+                    'useTimestampFromDataFile' => $config->preserveTimestamp(),
+                ],
+            );
+            $importJobs[$tableId] = $jobId;
+        }
+        foreach ($importJobs as $tableId => $jobId) {
+            $this->logger->info(sprintf('Waiting for import job for table %s', $tableId));
+            $job = $this->targetClient->waitForJob($jobId);
+            if ($job === null || $job['status'] !== 'success') {
+                $errorMessage = $job['error']['message'] ?? 'Unknown error';
+                $this->logger->warning(sprintf(
+                    'Import failed for table %s: %s',
+                    $tableId,
+                    $errorMessage,
+                ));
+            }
+        }
+    }
+
+    /**
+     * Downloads file from source and uploads to target.
+     * @param array<string, mixed> $tableInfo
+     * @return int|null The destination file ID, or null if dry run or large GCS table
+     */
+    private function downloadAndUpload(array $tableInfo, int $sourceFileId, Config $config): ?int
+    {
+        $sourceFileInfo = $this->sourceClient->getFile($sourceFileId);
+        $tmp = new Temp();
+        $optionUploadedFile = new FileUploadOptions();
+        assert(is_string($tableInfo['id']));
+        $tableIdStr = $tableInfo['id'];
+        $optionUploadedFile
+            ->setFederationToken(true)
+            ->setFileName($tableIdStr);
+        $tableSize = $sourceFileInfo['sizeBytes'];
+        if ($sourceFileInfo['provider'] === 'gcp' &&
+            $sourceFileInfo['isSliced'] === true &&
+            $tableSize > self::LARGE_GCS_TABLE_SIZE
+        ) {
+            $this->migrateGcsLargeTable->migrate(
+                $sourceFileId,
+                $tableInfo,
+                $config->preserveTimestamp(),
+                $tmp,
+            );
+            $tmp->remove();
+            return null;
+        } elseif ($sourceFileInfo['isSliced'] === true) {
+            $optionUploadedFile->setIsSliced(true);
+            if ($this->dryRun === false) {
+                $this->logger->info(sprintf('Downloading table %s', $tableIdStr));
+                $slices = $this->sourceClient->downloadSlicedFile($sourceFileId, $tmp->getTmpFolder());
+                $this->logger->info(sprintf('Uploading table %s', $tableIdStr));
+                $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);
+            } else {
+                $this->logger->info(sprintf('[dry-run] Migrate table %s', $tableIdStr));
+                $tmp->remove();
+                return null;
+            }
+        } else {
+            $fileName = $tmp->getTmpFolder() . '/' . $sourceFileInfo['name'];
+            if ($this->dryRun === false) {
+                $this->logger->info(sprintf('Downloading table %s', $tableIdStr));
+                $this->sourceClient->downloadFile($sourceFileId, $fileName);
+                $this->logger->info(sprintf('Uploading table %s', $tableIdStr));
+                $destinationFileId = $this->targetClient->uploadFile($fileName, $optionUploadedFile);
+            } else {
+                $this->logger->info(sprintf('[dry-run] Uploading table %s', $tableIdStr));
+                $tmp->remove();
+                return null;
+            }
+        }
+        $tmp->remove();
+        return $destinationFileId;
     }
 
     private function migrateTable(array $sourceTableInfo, Config $config): void


### PR DESCRIPTION
# feat: add parallel migration and cross-backend type conversion

## Summary
This PR adds two features to the SAPI migration mode:

### 1. Parallel Table Migration
Adds a new `parallelism` configuration parameter that enables parallel table migration when using SAPI mode. When `parallelism > 1`, tables are processed in batches where export jobs and import jobs are queued concurrently within each batch.

**Configuration:**
- `parallelism`: integer (default: 1, min: 1, max: 10)
- Default value of 1 preserves existing sequential behavior

**How it works:**
1. All tables are validated and buckets/tables are created sequentially (preparation phase)
2. Tables are split into batches of size `parallelism`
3. For each batch:
   - Queue all export jobs concurrently
   - Wait for all exports to complete
   - Download and upload files (sequential within batch)
   - Queue all import jobs concurrently
   - Wait for all imports to complete

### 2. Cross-Backend Type Conversion (New)
Fixes typed table migration between different storage backends (e.g., Snowflake → BigQuery). Previously, migrating typed tables across backends failed because source data types (e.g., `VARCHAR`, `NUMBER`, `TIMESTAMP_LTZ`) were passed directly to the destination, which expects different types (e.g., `STRING`, `INT64`, `TIMESTAMP`).

**How it works:**
1. Detects when source and destination bucket backends differ
2. Converts source types to base types using the `php-datatypes` library
3. Maps base types to appropriate destination backend types
4. Preserves nullable property for primary key compatibility

**Supported backends:** Snowflake, BigQuery (other backends will log a warning and skip type conversion)

## Review & Testing Checklist for Human
- [ ] **Test cross-backend migration (Snowflake → BigQuery)** - This is the primary fix; verify typed tables migrate correctly with proper type conversion
- [ ] **Verify type mapping accuracy** - Check that converted types are semantically correct (e.g., `NUMBER` → `INT64` or `NUMERIC` depending on precision)
- [ ] **Test with actual Keboola projects** - No functional tests were run; verify parallel migration works correctly with real tables
- [ ] **Test with large GCS tables (>50GB)** - These are handled by `MigrateGcsLargeTable`; verify they still migrate correctly
- [ ] **Verify error handling** - When a table fails in a batch, the code logs a warning and continues. Confirm this is acceptable.

**Recommended test plan:**
1. Test cross-backend migration: Migrate typed tables from Snowflake project to BigQuery project - verify types are converted correctly
2. Test same-backend migration: Migrate typed tables within same backend - verify original types are preserved
3. Configure component with `parallelism: 1` and migrate a few tables - verify behavior unchanged
4. Configure with `parallelism: 3` and migrate 5+ tables - verify all tables migrate correctly
5. Test dry-run mode with both features enabled

**To test with the new tag:**
```json
{
  "runtime": {
    "tag": "163-parallel-conversion-types"
  }
}
```

### Notes
- Link to Devin run: https://app.devin.ai/sessions/b19358e24a3648718a68c3cb1e6b3f38
- Previous Devin run (parallelism): https://app.devin.ai/sessions/b2efe11a017b4bc69eb21a72c4e732c1
- Requested by: Vojta Tuma (@yustme)

## Release Notes
**Justification, description**

Adds parallel table migration support and fixes cross-backend type conversion for typed tables.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low risk - parallelism defaults to 1 (sequential), cross-backend type conversion only activates when backends differ.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A