### PR TITLE
feat: add parallelism and skipExportInDryRun options for faster dry-run

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -214,6 +214,18 @@ class Config extends BaseConfig
         return (bool) $this->getValue(['parameters', 'dryRun']);
     }
 
+    public function shouldSkipExportInDryRun(): bool
+    {
+        return (bool) $this->getValue(['parameters', 'skipExportInDryRun']);
+    }
+
+    public function getConcurrency(): int
+    {
+        $value = $this->getValue(['parameters', 'concurrency'], 1);
+        assert(is_numeric($value));
+        return (int) $value;
+    }
+
     public function isSourceByodb(): bool
     {
         return (bool) $this->getValue(['parameters',  'isSourceByodb']);

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -19,6 +19,8 @@ class ConfigDefinition extends BaseConfigDefinition
             ->children()
                 ->enumNode('mode')->values(['sapi', 'database'])->defaultValue('sapi')->end()
                 ->booleanNode('dryRun')->defaultFalse()->end()
+                ->booleanNode('skipExportInDryRun')->defaultFalse()->end()
+                ->integerNode('concurrency')->defaultValue(1)->min(1)->max(20)->end()
                 ->booleanNode('isSourceByodb')->defaultFalse()->end()
                 ->scalarNode('sourceByodb')->end()
                 ->scalarNode('sourceKbcUrl')->isRequired()->cannotBeEmpty()->end()

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -40,68 +40,167 @@ class SapiMigrate implements MigrateInterface
 
     public function migrate(Config $config): void
     {
-        foreach ($config->getMigrateTables() ?: $this->getAllTables() as $tableId) {
-            try {
-                $tableInfo = $this->sourceClient->getTable($tableId);
-            } catch (ClientException $e) {
-                $this->logger->warning(sprintf(
-                    'Skipping migration Table ID "%s". Reason: "%s".',
-                    $tableId,
-                    $e->getMessage(),
-                ));
-                continue;
-            }
-            if ($tableInfo['bucket']['stage'] === 'sys') {
-                $this->logger->warning(sprintf('Skipping table %s (sys bucket)', $tableInfo['id']));
-                continue;
-            }
+        $tableIds = $config->getMigrateTables() ?: $this->getAllTables();
+        $concurrency = $config->getConcurrency();
 
-            if ($tableInfo['isAlias']) {
-                $this->logger->warning(sprintf('Skipping table %s (alias)', $tableInfo['id']));
-                continue;
-            }
-
-            if (!in_array($tableInfo['bucket']['id'], $this->bucketsExist) &&
-                !$this->targetClient->bucketExists($tableInfo['bucket']['id'])) {
-                if ($this->dryRun) {
-                    $this->logger->info(sprintf('[dry-run] Creating bucket %s', $tableInfo['bucket']['id']));
-                } else {
-                    $this->logger->info(sprintf('Creating bucket %s', $tableInfo['bucket']['id']));
-                    $this->bucketsExist[] = $tableInfo['bucket']['id'];
-
-                    $this->storageModifier->createBucket($tableInfo['bucket']['id']);
-                }
-            }
-
-            if (!$this->targetClient->tableExists($tableId)) {
-                if ($this->dryRun) {
-                    $this->logger->info(sprintf('[dry-run] Creating table %s', $tableInfo['id']));
-                } else {
-                    $this->logger->info(sprintf('Creating table %s', $tableInfo['id']));
-                    $this->storageModifier->createTable($tableInfo);
-                }
-            }
-
-            $this->migrateTable($tableInfo, $config);
+        if ($concurrency > 1) {
+            $this->migrateTablesInParallel($tableIds, $config, $concurrency);
+        } else {
+            $this->migrateTablesSequentially($tableIds, $config);
         }
     }
 
-    private function migrateTable(array $sourceTableInfo, Config $config): void
+    /**
+     * @param string[] $tableIds
+     */
+    private function migrateTablesSequentially(array $tableIds, Config $config): void
     {
-        $this->logger->info(sprintf('Exporting table %s', $sourceTableInfo['id']));
-        $file = $this->sourceClient->exportTableAsync($sourceTableInfo['id'], [
-            'gzip' => true,
-            'includeInternalTimestamp' => $config->preserveTimestamp(),
-        ]);
+        foreach ($tableIds as $tableId) {
+            $this->processTable($tableId, $config);
+        }
+    }
 
-        $sourceFileId = $file['file']['id'];
+    /**
+     * @param string[] $tableIds
+     */
+    private function migrateTablesInParallel(array $tableIds, Config $config, int $concurrency): void
+    {
+        $batches = array_chunk($tableIds, max(1, $concurrency));
+        $totalBatches = count($batches);
+
+        foreach ($batches as $batchIndex => $batch) {
+            $this->logger->info(sprintf(
+                'Processing batch %d/%d (%d tables)',
+                $batchIndex + 1,
+                $totalBatches,
+                count($batch),
+            ));
+
+            $tableInfos = [];
+            foreach ($batch as $tableId) {
+                try {
+                    $tableInfo = $this->sourceClient->getTable($tableId);
+                    if ($tableInfo['bucket']['stage'] === 'sys') {
+                        $this->logger->warning(sprintf('Skipping table %s (sys bucket)', $tableInfo['id']));
+                        continue;
+                    }
+                    if ($tableInfo['isAlias']) {
+                        $this->logger->warning(sprintf('Skipping table %s (alias)', $tableInfo['id']));
+                        continue;
+                    }
+                    $tableInfos[] = $tableInfo;
+                } catch (ClientException $e) {
+                    $this->logger->warning(sprintf(
+                        'Skipping migration Table ID "%s". Reason: "%s".',
+                        $tableId,
+                        $e->getMessage(),
+                    ));
+                }
+            }
+
+            $this->ensureBucketsExist($tableInfos);
+            $this->ensureTablesExist($tableInfos);
+
+            if ($this->dryRun && $config->shouldSkipExportInDryRun()) {
+                foreach ($tableInfos as $tableInfo) {
+                    $this->logger->info(sprintf(
+                        '[dry-run] Would migrate table %s (rows: %s, size: %s bytes)',
+                        $tableInfo['id'],
+                        $tableInfo['rowsCount'] ?? 'unknown',
+                        $tableInfo['dataSizeBytes'] ?? 'unknown',
+                    ));
+                }
+                continue;
+            }
+
+            $exportJobs = $this->startExportJobs($tableInfos, $config);
+
+            foreach ($exportJobs as $index => $exportJob) {
+                $tableInfo = $tableInfos[$index];
+                $this->processExportedTable($tableInfo, $exportJob, $config);
+            }
+        }
+    }
+
+    /**
+     * @param array<array<string, mixed>> $tableInfos
+     */
+    private function ensureBucketsExist(array $tableInfos): void
+    {
+        foreach ($tableInfos as $tableInfo) {
+            $bucket = $tableInfo['bucket'];
+            assert(is_array($bucket) && isset($bucket['id']) && is_string($bucket['id']));
+            $bucketId = $bucket['id'];
+            if (!in_array($bucketId, $this->bucketsExist, true) &&
+                !$this->targetClient->bucketExists($bucketId)) {
+                if ($this->dryRun) {
+                    $this->logger->info(sprintf('[dry-run] Creating bucket %s', $bucketId));
+                } else {
+                    $this->logger->info(sprintf('Creating bucket %s', $bucketId));
+                    $this->storageModifier->createBucket($bucketId);
+                }
+                $this->bucketsExist[] = $bucketId;
+            }
+        }
+    }
+
+    /**
+     * @param array<array<string, mixed>> $tableInfos
+     */
+    private function ensureTablesExist(array $tableInfos): void
+    {
+        foreach ($tableInfos as $tableInfo) {
+            assert(isset($tableInfo['id']) && is_string($tableInfo['id']));
+            $tableId = $tableInfo['id'];
+            if (!$this->targetClient->tableExists($tableId)) {
+                if ($this->dryRun) {
+                    $this->logger->info(sprintf('[dry-run] Creating table %s', $tableId));
+                } else {
+                    $this->logger->info(sprintf('Creating table %s', $tableId));
+                    $this->storageModifier->createTable($tableInfo);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param array<array<string, mixed>> $tableInfos
+     * @return array<array<string, mixed>>
+     */
+    private function startExportJobs(array $tableInfos, Config $config): array
+    {
+        $exportJobs = [];
+        foreach ($tableInfos as $tableInfo) {
+            assert(isset($tableInfo['id']) && is_string($tableInfo['id']));
+            $tableId = $tableInfo['id'];
+            $this->logger->info(sprintf('Exporting table %s', $tableId));
+            $file = $this->sourceClient->exportTableAsync($tableId, [
+                'gzip' => true,
+                'includeInternalTimestamp' => $config->preserveTimestamp(),
+            ]);
+            $exportJobs[] = $file;
+        }
+        return $exportJobs;
+    }
+
+    /**
+     * @param array<string, mixed> $sourceTableInfo
+     * @param array<string, mixed> $exportJob
+     */
+    private function processExportedTable(array $sourceTableInfo, array $exportJob, Config $config): void
+    {
+        $file = $exportJob['file'];
+        assert(is_array($file) && isset($file['id']) && is_numeric($file['id']));
+        $sourceFileId = (int) $file['id'];
         $sourceFileInfo = $this->sourceClient->getFile($sourceFileId);
+        assert(isset($sourceTableInfo['id']) && is_string($sourceTableInfo['id']));
+        $tableId = $sourceTableInfo['id'];
 
         $tmp = new Temp();
         $optionUploadedFile = new FileUploadOptions();
         $optionUploadedFile
             ->setFederationToken(true)
-            ->setFileName($sourceTableInfo['id'])
+            ->setFileName($tableId)
         ;
         $tableSize = $sourceFileInfo['sizeBytes'];
         if ($sourceFileInfo['provider'] === 'gcp' &&
@@ -120,34 +219,33 @@ class SapiMigrate implements MigrateInterface
             $optionUploadedFile->setIsSliced(true);
 
             if ($this->dryRun === false) {
-                $this->logger->info(sprintf('Downloading table %s', $sourceTableInfo['id']));
+                $this->logger->info(sprintf('Downloading table %s', $tableId));
                 $slices = $this->sourceClient->downloadSlicedFile($sourceFileId, $tmp->getTmpFolder());
 
-                $this->logger->info(sprintf('Uploading table %s', $sourceTableInfo['id']));
+                $this->logger->info(sprintf('Uploading table %s', $tableId));
                 $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);
             } else {
-                $this->logger->info(sprintf('[dry-run] Migrate table %s', $sourceTableInfo['id']));
+                $this->logger->info(sprintf('[dry-run] Migrate table %s', $tableId));
                 $destinationFileId = null;
             }
         } else {
             $fileName = $tmp->getTmpFolder() . '/' . $sourceFileInfo['name'];
 
             if ($this->dryRun === false) {
-                $this->logger->info(sprintf('Downloading table %s', $sourceTableInfo['id']));
+                $this->logger->info(sprintf('Downloading table %s', $tableId));
                 $this->sourceClient->downloadFile($sourceFileId, $fileName);
 
-                $this->logger->info(sprintf('Uploading table %s', $sourceTableInfo['id']));
+                $this->logger->info(sprintf('Uploading table %s', $tableId));
                 $destinationFileId = $this->targetClient->uploadFile($fileName, $optionUploadedFile);
             } else {
-                $this->logger->info(sprintf('[dry-run] Uploading table %s', $sourceTableInfo['id']));
+                $this->logger->info(sprintf('[dry-run] Uploading table %s', $tableId));
                 $destinationFileId = null;
             }
         }
 
         if ($this->dryRun === false) {
-            // Upload data to table
             $this->targetClient->writeTableAsyncDirect(
-                $sourceTableInfo['id'],
+                $tableId,
                 [
                     'name' => $sourceTableInfo['name'],
                     'dataFileId' => $destinationFileId,
@@ -156,12 +254,88 @@ class SapiMigrate implements MigrateInterface
                 ],
             );
         } else {
+            assert(isset($sourceTableInfo['name']) && is_string($sourceTableInfo['name']));
             $this->logger->info(sprintf('[dry-run] Import data to table "%s"', $sourceTableInfo['name']));
         }
 
         $tmp->remove();
     }
 
+    private function processTable(string $tableId, Config $config): void
+    {
+        try {
+            $tableInfo = $this->sourceClient->getTable($tableId);
+        } catch (ClientException $e) {
+            $this->logger->warning(sprintf(
+                'Skipping migration Table ID "%s". Reason: "%s".',
+                $tableId,
+                $e->getMessage(),
+            ));
+            return;
+        }
+        if ($tableInfo['bucket']['stage'] === 'sys') {
+            $this->logger->warning(sprintf('Skipping table %s (sys bucket)', $tableInfo['id']));
+            return;
+        }
+
+        if ($tableInfo['isAlias']) {
+            $this->logger->warning(sprintf('Skipping table %s (alias)', $tableInfo['id']));
+            return;
+        }
+
+        if (!in_array($tableInfo['bucket']['id'], $this->bucketsExist) &&
+            !$this->targetClient->bucketExists($tableInfo['bucket']['id'])) {
+            if ($this->dryRun) {
+                $this->logger->info(sprintf('[dry-run] Creating bucket %s', $tableInfo['bucket']['id']));
+            } else {
+                $this->logger->info(sprintf('Creating bucket %s', $tableInfo['bucket']['id']));
+                $this->bucketsExist[] = $tableInfo['bucket']['id'];
+
+                $this->storageModifier->createBucket($tableInfo['bucket']['id']);
+            }
+        }
+
+        if (!$this->targetClient->tableExists($tableId)) {
+            if ($this->dryRun) {
+                $this->logger->info(sprintf('[dry-run] Creating table %s', $tableInfo['id']));
+            } else {
+                $this->logger->info(sprintf('Creating table %s', $tableInfo['id']));
+                $this->storageModifier->createTable($tableInfo);
+            }
+        }
+
+        if ($this->dryRun && $config->shouldSkipExportInDryRun()) {
+            $this->logger->info(sprintf(
+                '[dry-run] Would migrate table %s (rows: %s, size: %s bytes)',
+                $tableInfo['id'],
+                $tableInfo['rowsCount'] ?? 'unknown',
+                $tableInfo['dataSizeBytes'] ?? 'unknown',
+            ));
+            return;
+        }
+
+        $this->migrateTable($tableInfo, $config);
+    }
+
+    /**
+     * @param array<string, mixed> $sourceTableInfo
+     */
+    private function migrateTable(array $sourceTableInfo, Config $config): void
+    {
+        assert(isset($sourceTableInfo['id']) && is_string($sourceTableInfo['id']));
+        $tableId = $sourceTableInfo['id'];
+        $this->logger->info(sprintf('Exporting table %s', $tableId));
+        $file = $this->sourceClient->exportTableAsync($tableId, [
+            'gzip' => true,
+            'includeInternalTimestamp' => $config->preserveTimestamp(),
+        ]);
+
+        $this->processExportedTable($sourceTableInfo, $file, $config);
+    }
+
+    /**
+     * @return string[]
+     */
     private function getAllTables(): array
     {
         $buckets = $this->sourceClient->listBuckets();


### PR DESCRIPTION
## Summary

Adds two new configuration parameters to significantly speed up dry-run mode and enable batch processing of tables:

- **`skipExportInDryRun`** (boolean, default: `false`): When enabled with `dryRun=true`, skips the expensive `exportTableAsync()` calls and just logs table metadata (row count, size). This addresses the issue where dry-run was taking 48+ hours because it still performed actual exports.

- **`concurrency`** (integer, default: `1`, min: `1`, max: `20`): Controls batch size for table processing. Tables are chunked into batches and processed together. Note: This is batch processing, not true async parallelism.

The `SapiMigrate` strategy was refactored to support these features while maintaining backward compatibility (default `concurrency=1` preserves original sequential behavior).

## Review & Testing Checklist for Human

- [ ] **Verify backward compatibility**: Run with default settings (`concurrency=1`, `skipExportInDryRun=false`) and confirm behavior matches the previous version
- [ ] **Test skipExportInDryRun**: Run with `dryRun=true` and `skipExportInDryRun=true` - verify no export jobs are triggered and logs show table metadata
- [ ] **Test batch processing**: Run with `concurrency > 1` and verify tables are processed in batches correctly
- [ ] **Review index alignment** in `migrateTablesInParallel()`: The `$exportJobs[$index]` must align with `$tableInfos[$index]` after filtering - verify this works when some tables are skipped
- [ ] **No tests were added** - consider adding functional tests for the new parameters

**Recommended test plan**: 
1. Run dry-run with `skipExportInDryRun=true` on a project with many tables - should complete in minutes instead of hours
2. Run actual migration with `concurrency=5` on a test project and verify all tables migrate correctly

### Notes

- The "parallelism" is batch processing (tables chunked into groups), not true async parallelism due to PHP limitations
- Heavy use of `assert()` for PHPStan type safety - these will throw in production if data structure assumptions are violated
- Only applies to SAPI mode (`mode: sapi`), not database mode

Link to Devin run: https://app.devin.ai/sessions/2e935f2b3678404788b3849dc382cc6d
Requested by: Vojta Tuma (@yustme)

## Release Notes
**Justification, description**

Adds `skipExportInDryRun` parameter to skip expensive exports during dry-run validation, and `concurrency` parameter for batch processing of tables. Addresses performance issue where dry-run took 48+ hours on projects with many tables.

**Plans for Customer Communication**

N/A - Optional parameters with backward-compatible defaults

**Impact Analysis**

Low risk - new optional parameters with defaults that preserve existing behavior

**Deployment Plan**

Standard deployment

**Rollback Plan**

Standard rollback - no breaking changes


**Post-Release Support Plan**

N/A