### PR TITLE
fix: skip table export in dry-run mode to prevent blocking

### DIFF
--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -88,6 +88,11 @@ class SapiMigrate implements MigrateInterface
 
     private function migrateTable(array $sourceTableInfo, Config $config): void
     {
+        if ($this->dryRun) {
+            $this->logger->info(sprintf('[dry-run] Migrate table %s', $sourceTableInfo['id']));
+            return;
+        }
+
         $this->logger->info(sprintf('Exporting table %s', $sourceTableInfo['id']));
         $file = $this->sourceClient->exportTableAsync($sourceTableInfo['id'], [
             'gzip' => true,
@@ -119,45 +124,31 @@ class SapiMigrate implements MigrateInterface
         } elseif ($sourceFileInfo['isSliced'] === true) {
             $optionUploadedFile->setIsSliced(true);
 
-            if ($this->dryRun === false) {
-                $this->logger->info(sprintf('Downloading table %s', $sourceTableInfo['id']));
-                $slices = $this->sourceClient->downloadSlicedFile($sourceFileId, $tmp->getTmpFolder());
+            $this->logger->info(sprintf('Downloading table %s', $sourceTableInfo['id']));
+            $slices = $this->sourceClient->downloadSlicedFile($sourceFileId, $tmp->getTmpFolder());
 
-                $this->logger->info(sprintf('Uploading table %s', $sourceTableInfo['id']));
-                $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);
-            } else {
-                $this->logger->info(sprintf('[dry-run] Migrate table %s', $sourceTableInfo['id']));
-                $destinationFileId = null;
-            }
+            $this->logger->info(sprintf('Uploading table %s', $sourceTableInfo['id']));
+            $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);
         } else {
             $fileName = $tmp->getTmpFolder() . '/' . $sourceFileInfo['name'];
 
-            if ($this->dryRun === false) {
-                $this->logger->info(sprintf('Downloading table %s', $sourceTableInfo['id']));
-                $this->sourceClient->downloadFile($sourceFileId, $fileName);
+            $this->logger->info(sprintf('Downloading table %s', $sourceTableInfo['id']));
+            $this->sourceClient->downloadFile($sourceFileId, $fileName);
 
-                $this->logger->info(sprintf('Uploading table %s', $sourceTableInfo['id']));
-                $destinationFileId = $this->targetClient->uploadFile($fileName, $optionUploadedFile);
-            } else {
-                $this->logger->info(sprintf('[dry-run] Uploading table %s', $sourceTableInfo['id']));
-                $destinationFileId = null;
-            }
+            $this->logger->info(sprintf('Uploading table %s', $sourceTableInfo['id']));
+            $destinationFileId = $this->targetClient->uploadFile($fileName, $optionUploadedFile);
         }
 
-        if ($this->dryRun === false) {
-            // Upload data to table
-            $this->targetClient->writeTableAsyncDirect(
-                $sourceTableInfo['id'],
-                [
-                    'name' => $sourceTableInfo['name'],
-                    'dataFileId' => $destinationFileId,
-                    'columns' => $sourceTableInfo['columns'],
-                    'useTimestampFromDataFile' => $config->preserveTimestamp(),
-                ],
-            );
-        } else {
-            $this->logger->info(sprintf('[dry-run] Import data to table "%s"', $sourceTableInfo['name']));
-        }
+        // Upload data to table
+        $this->targetClient->writeTableAsyncDirect(
+            $sourceTableInfo['id'],
+            [
+                'name' => $sourceTableInfo['name'],
+                'dataFileId' => $destinationFileId,
+                'columns' => $sourceTableInfo['columns'],
+                'useTimestampFromDataFile' => $config->preserveTimestamp(),
+            ],
+        );
 
         $tmp->remove();
     }

--- a/tests/functional/dry-run/expected-stdout
+++ b/tests/functional/dry-run/expected-stdout
@@ -1,3 +1,1 @@
-Exporting table in.c-test.simple
 [dry-run] Migrate table in.c-test.simple
-[dry-run] Import data to table "simple"


### PR DESCRIPTION
## Summary

Fixes an issue where dry-run mode was still executing `exportTableAsync()` on source tables, which could lock tables and block transformations from inserting data. The export operation was also taking a long time unnecessarily.

The fix adds an early return at the beginning of `migrateTable()` when dry-run mode is enabled, preventing any actual Storage API operations from being executed.

**Before:** Dry-run mode would export the table (potentially locking it), then skip the download/upload/import steps.

**After:** Dry-run mode skips the entire migration process for each table, only logging what would be migrated.

## Review & Testing Checklist for Human

- [ ] Verify the functional test passes with the updated expected output (fewer log lines in dry-run mode)
- [ ] Test dry-run mode manually to confirm tables are no longer exported/locked
- [ ] Check if `MigrateGcsLargeTable` class has similar issues (it has its own dry-run check but is only reached after export)

### Recommended Test Plan
1. Run the component in dry-run mode against a project with tables
2. Verify the job completes quickly without "Exporting table" log messages
3. Confirm that concurrent transformations can insert data into tables during the dry-run

### Notes

Link to Devin run: https://app.devin.ai/sessions/1e23cb14931a46ec889bc1243c1a2df5
Requested by: Vojta Tuma (@yustme)

## Release Notes
**Justification, description**

Bug fix: Dry-run mode was incorrectly executing table exports which could lock tables and block other operations.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low risk - only affects dry-run mode behavior, making it faster and non-blocking as expected.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A