### PR TITLE
fix: handle cross-backend type mapping for typed tables

### DIFF
--- a/src/StorageModifier.php
+++ b/src/StorageModifier.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Keboola\AppProjectMigrateLargeTables;
 
 use Keboola\Csv\CsvFile;
+use Keboola\Datatype\Definition\Bigquery;
+use Keboola\Datatype\Definition\Snowflake;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Exception as StorageApiException;
@@ -15,6 +17,9 @@ use Keboola\Temp\Temp;
 class StorageModifier
 {
     private Temp $tmp;
+
+    /** @var array<string, string> */
+    private array $bucketBackends = [];
 
     public function __construct(readonly Client $client)
     {
@@ -33,12 +38,22 @@ class StorageModifier
     public function createTable(array $tableInfo): void
     {
         if ($tableInfo['isTyped']) {
-            $this->createTypedTable($tableInfo);
+            $destinationBackend = $this->getDestinationBucketBackend($tableInfo['bucket']['id']);
+            $this->createTypedTable($tableInfo, $destinationBackend);
         } else {
             $this->createNonTypedTable($tableInfo);
         }
 
         $this->restoreTableColumnsMetadata($tableInfo, $tableInfo['id'], new Metadata($this->client));
+    }
+
+    private function getDestinationBucketBackend(string $bucketId): string
+    {
+        if (!isset($this->bucketBackends[$bucketId])) {
+            $bucket = $this->client->getBucket($bucketId);
+            $this->bucketBackends[$bucketId] = $bucket['backend'];
+        }
+        return $this->bucketBackends[$bucketId];
     }
 
     private function createNonTypedTable(array $tableInfo): void
@@ -57,8 +72,9 @@ class StorageModifier
         );
     }
 
-    private function createTypedTable(array $tableInfo): void
+    private function createTypedTable(array $tableInfo, string $destinationBackend): void
     {
+        $sourceBackend = $tableInfo['bucket']['backend'];
         $columns = [];
         foreach ($tableInfo['columns'] as $column) {
             $columns[$column] = [];
@@ -73,15 +89,24 @@ class StorageModifier
                 $columnMetadata[$metadata['key']] = $metadata['value'];
             }
 
-            $definition = [
-                'type' => $columnMetadata['KBC.datatype.type'],
-                'nullable' => $columnMetadata['KBC.datatype.nullable'] === '1',
-            ];
-            if (isset($columnMetadata['KBC.datatype.length'])) {
-                $definition['length'] = $columnMetadata['KBC.datatype.length'];
-            }
-            if (isset($columnMetadata['KBC.datatype.default'])) {
-                $definition['default'] = $columnMetadata['KBC.datatype.default'];
+            if ($destinationBackend !== $sourceBackend) {
+                $sourceBaseType = $this->getBaseType(
+                    $sourceBackend,
+                    $columnMetadata['KBC.datatype.type'],
+                );
+                $definition = $this->getDefinitionForBasetype($destinationBackend, $sourceBaseType);
+                $definition['nullable'] = $columnMetadata['KBC.datatype.nullable'] === '1';
+            } else {
+                $definition = [
+                    'type' => $columnMetadata['KBC.datatype.type'],
+                    'nullable' => $columnMetadata['KBC.datatype.nullable'] === '1',
+                ];
+                if (isset($columnMetadata['KBC.datatype.length'])) {
+                    $definition['length'] = $columnMetadata['KBC.datatype.length'];
+                }
+                if (isset($columnMetadata['KBC.datatype.default'])) {
+                    $definition['default'] = $columnMetadata['KBC.datatype.default'];
+                }
             }
 
             $columns[$columnName] = [
@@ -167,5 +192,44 @@ class StorageModifier
             ];
         }
         return $result;
+    }
+
+    private function getBaseType(string $backend, string $originalType): ?string
+    {
+        switch ($backend) {
+            case 'snowflake':
+                return (new Snowflake($originalType))->getBasetype();
+            case 'bigquery':
+                return (new Bigquery($originalType))->getBasetype();
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * @return array{type: string, length: string|null, nullable: bool}
+     */
+    private function getDefinitionForBasetype(string $backend, ?string $basetype): array
+    {
+        if ($basetype === null) {
+            return [
+                'type' => 'STRING',
+                'length' => null,
+                'nullable' => true,
+            ];
+        }
+
+        switch ($backend) {
+            case 'snowflake':
+                return Snowflake::getDefinitionForBasetype($basetype)->toArray();
+            case 'bigquery':
+                return Bigquery::getDefinitionForBasetype($basetype)->toArray();
+            default:
+                return [
+                    'type' => 'STRING',
+                    'length' => null,
+                    'nullable' => true,
+                ];
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes an internal error that occurs when migrating typed tables between projects with different storage backends (e.g., Snowflake → BigQuery). The component was passing source-native types (VARCHAR, NUMBER) directly to the Storage API, which fails because the target backend doesn't recognize those types.

**Root cause:** When creating typed tables in the destination project, the code used `KBC.datatype.type` from source metadata directly, which contains backend-specific types.

**Fix:** When source and destination backends differ:
1. Convert source type to a basetype using `php-datatypes` library
2. Generate appropriate native type for the destination backend using `getDefinitionForBasetype()`
3. Preserve original behavior for same-backend migrations

This approach mirrors the pattern used in `php-kbc-project-restore`.

## Review & Testing Checklist for Human

- [ ] **Verify type mapping correctness**: Test migrating a typed table from Snowflake to BigQuery and vice versa - ensure column types are correctly converted
- [ ] **Check edge cases**: What happens with complex types (VARIANT, ARRAY, STRUCT) that may not have direct equivalents?
- [ ] **Validate fallback behavior**: The code falls back to STRING type for unknown backends/basetypes - confirm this is acceptable
- [ ] **No unit tests added**: Consider whether tests should be added for the cross-backend type mapping logic

**Recommended test plan:**
1. Set up a migration from a Snowflake-backed project to a BigQuery-backed project with typed tables containing various column types (VARCHAR, NUMBER, DATE, TIMESTAMP, etc.)
2. Verify the migration completes without the "Type VARCHAR not recognized" error
3. Confirm the resulting table in BigQuery has appropriate column types

### Notes

- Only `snowflake` and `bigquery` backends are explicitly handled; other backends fall back to STRING type
- Bucket backend is cached to avoid repeated API calls
- Link to Devin run: https://app.devin.ai/sessions/73acfec70b754c749b1e049927f44feb
- Requested by: @ZdenekSrotyr

## Release Notes
**Justification, description**

Fixes cross-backend migration failures when migrating typed tables between projects with different storage backends (e.g., Snowflake to BigQuery).

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low risk - only affects cross-backend migrations of typed tables. Same-backend migrations are unchanged.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A