### PR TITLE
fix: handle cross-backend type mapping for typed tables

### DIFF
--- a/src/StorageModifier.php
+++ b/src/StorageModifier.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Keboola\AppProjectMigrateLargeTables;
 
 use Keboola\Csv\CsvFile;
+use Keboola\Datatype\Definition\Bigquery;
+use Keboola\Datatype\Definition\Snowflake;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Exception as StorageApiException;
@@ -59,6 +61,9 @@ class StorageModifier
 
     private function createTypedTable(array $tableInfo): void
     {
+        $sourceBackend = $tableInfo['bucket']['backend'];
+        $destinationBackend = $this->getDestinationBucketBackend($tableInfo['bucket']['id']);
+
         $columns = [];
         foreach ($tableInfo['columns'] as $column) {
             $columns[$column] = [];
@@ -73,15 +78,27 @@ class StorageModifier
                 $columnMetadata[$metadata['key']] = $metadata['value'];
             }
 
-            $definition = [
-                'type' => $columnMetadata['KBC.datatype.type'],
-                'nullable' => $columnMetadata['KBC.datatype.nullable'] === '1',
-            ];
-            if (isset($columnMetadata['KBC.datatype.length'])) {
-                $definition['length'] = $columnMetadata['KBC.datatype.length'];
-            }
-            if (isset($columnMetadata['KBC.datatype.default'])) {
-                $definition['default'] = $columnMetadata['KBC.datatype.default'];
+            if ($destinationBackend !== $sourceBackend) {
+                // Cross-backend migration: use basetype to get correct native type for target backend
+                $sourceBaseType = $this->getBaseType(
+                    $sourceBackend,
+                    $columnMetadata['KBC.datatype.type'],
+                );
+                $definition = $this->getDefinitionForBasetype($destinationBackend, $sourceBaseType);
+                // Preserve nullable property from source
+                $definition['nullable'] = $columnMetadata['KBC.datatype.nullable'] === '1';
+            } else {
+                // Same backend: use original type directly
+                $definition = [
+                    'type' => $columnMetadata['KBC.datatype.type'],
+                    'nullable' => $columnMetadata['KBC.datatype.nullable'] === '1',
+                ];
+                if (isset($columnMetadata['KBC.datatype.length'])) {
+                    $definition['length'] = $columnMetadata['KBC.datatype.length'];
+                }
+                if (isset($columnMetadata['KBC.datatype.default'])) {
+                    $definition['default'] = $columnMetadata['KBC.datatype.default'];
+                }
             }
 
             $columns[$columnName] = [
@@ -165,6 +182,52 @@ class StorageModifier
                 'key' => $item['key'],
                 'value' => $item['value'],
             ];
+        }
+        return $result;
+    }
+
+    private function getDestinationBucketBackend(string $bucketId): string
+    {
+        $bucket = $this->client->getBucket($bucketId);
+        return $bucket['backend'];
+    }
+
+    private function getBaseType(string $backend, string $originalType): ?string
+    {
+        switch ($backend) {
+            case 'snowflake':
+                return (new Snowflake($originalType))->getBasetype();
+            case 'bigquery':
+                return (new Bigquery($originalType))->getBasetype();
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * @return array{type: string, length?: string}
+     */
+    private function getDefinitionForBasetype(string $backend, ?string $basetype): array
+    {
+        if ($basetype === null) {
+            // Fallback to STRING type if basetype cannot be determined
+            return ['type' => 'STRING'];
+        }
+
+        switch ($backend) {
+            case 'snowflake':
+                $definition = Snowflake::getDefinitionForBasetype($basetype);
+                break;
+            case 'bigquery':
+                $definition = Bigquery::getDefinitionForBasetype($basetype);
+                break;
+            default:
+                return ['type' => 'STRING'];
+        }
+
+        $result = ['type' => $definition->getType()];
+        if ($definition->getLength() !== null) {
+            $result['length'] = $definition->getLength();
         }
         return $result;
     }


### PR DESCRIPTION
## Summary

Fixes internal errors when migrating typed tables between different storage backends (e.g., Snowflake to BigQuery). The component was using the source backend's native type directly (e.g., `VARCHAR`, `NUMBER`), which caused errors like `Type VARCHAR not recognized` on BigQuery.

The fix detects cross-backend migrations and uses the basetype (backend-agnostic type) to determine the correct native type for the target backend via `getDefinitionForBasetype()`. This approach mirrors the solution in `php-kbc-project-restore`.

**Root cause from Datadog logs:**
```
Keboola\StorageApi\ClientException: Invalid request:
- columns[0][definition][type]: "Type VARCHAR not recognized. Possible values are [BOOL|BYTES|DATE|...]"
```

## Review & Testing Checklist for Human

- [ ] **Verify loss of `length` and `default` properties is acceptable** - During cross-backend migration, only `nullable` is preserved from the source. The `length` and `default` values are derived from the basetype definition instead. This may cause precision loss for certain column types.
- [ ] **Confirm fallback behavior** - When basetype cannot be determined (unsupported source backend), the code falls back to `STRING` type. Verify this is the desired behavior.
- [ ] **Test with actual cross-backend migration** - Run a migration from Snowflake to BigQuery with typed tables to verify the fix works end-to-end.
- [ ] **Consider adding unit tests** - No tests were added for the new type mapping logic.

### Notes

- Only `snowflake` and `bigquery` backends are supported for type conversion. Other backends (like `synapse`) will use fallback behavior.
- The fix adds one additional API call (`getBucket`) to determine the destination backend type.
- Link to Devin run: https://app.devin.ai/sessions/71fdccf590ea4cfcb1d905d9e95c4840
- Requested by: @ZdenekSrotyr

## Release Notes
**Justification, description**

Fix for cross-backend typed table migration failures (e.g., Snowflake to BigQuery)

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low risk - only affects cross-backend migrations of typed tables

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A