### PR TITLE
feat: add chunkSize parameter to configure large table threshold

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -253,4 +253,22 @@ class Config extends BaseConfig
     {
         return $this->getIntValue(['parameters', 'parallelism'], 1);
     }
+
+    /**
+     * Get the chunk size threshold in bytes for large table migration.
+     * Returns null if not set (uses default 50GB).
+     */
+    public function getChunkSizeBytes(): ?int
+    {
+        $chunkSize = $this->getValue(['parameters', 'chunkSize']);
+        if ($chunkSize === null || !is_string($chunkSize)) {
+            return null;
+        }
+        // Parse "NGB" format to bytes
+        preg_match('/^(\d+)GB$/i', $chunkSize, $matches);
+        if (!isset($matches[1])) {
+            return null;
+        }
+        return (int) $matches[1] * 1000 * 1000 * 1000;
+    }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -257,6 +257,7 @@ class Config extends BaseConfig
     /**
      * Get the chunk size threshold in bytes for large table migration.
      * Returns null if not set (uses default 50GB).
+     * Supports MB, GB, and TB formats (e.g., "10MB", "100GB", "1TB").
      */
     public function getChunkSizeBytes(): ?int
     {
@@ -264,11 +265,18 @@ class Config extends BaseConfig
         if ($chunkSize === null || !is_string($chunkSize)) {
             return null;
         }
-        // Parse "NGB" format to bytes
-        preg_match('/^(\d+)GB$/i', $chunkSize, $matches);
-        if (!isset($matches[1])) {
+        // Parse "N[MB|GB|TB]" format to bytes
+        preg_match('/^(\d+)(MB|GB|TB)$/i', $chunkSize, $matches);
+        if (!isset($matches[1]) || !isset($matches[2])) {
             return null;
         }
-        return (int) $matches[1] * 1000 * 1000 * 1000;
+        $value = (int) $matches[1];
+        $unit = strtoupper($matches[2]);
+        $multipliers = [
+            'MB' => 1000 * 1000,
+            'GB' => 1000 * 1000 * 1000,
+            'TB' => 1000 * 1000 * 1000 * 1000,
+        ];
+        return $value * $multipliers[$unit];
     }
 }

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -26,6 +26,18 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->scalarNode('#sourceKbcToken')->isRequired()->cannotBeEmpty()->end()
                 ->arrayNode('includeWorkspaceSchemas')->prototype('scalar')->end()->end()
                 ->booleanNode('preserveTimestamp')->defaultFalse()->end()
+                ->scalarNode('chunkSize')
+                    ->defaultNull()
+                    ->validate()
+                        ->ifTrue(function ($v) {
+                            if ($v === null) {
+                                return false;
+                            }
+                            return !preg_match('/^\d+GB$/i', $v);
+                        })
+                        ->thenInvalid('chunkSize must be in format "NGB" (e.g., "100GB")')
+                    ->end()
+                ->end()
                 ->arrayNode('tables')->prototype('scalar')->end()->end()
                 ->booleanNode('migrateData')->defaultTrue()->end()
                 ->arrayNode('replica')

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -33,9 +33,9 @@ class ConfigDefinition extends BaseConfigDefinition
                             if ($v === null) {
                                 return false;
                             }
-                            return !preg_match('/^\d+GB$/i', $v);
+                            return !preg_match('/^\d+(MB|GB|TB)$/i', $v);
                         })
-                        ->thenInvalid('chunkSize must be in format "NGB" (e.g., "100GB")')
+                        ->thenInvalid('chunkSize must be in format "N[MB|GB|TB]" (e.g., "10MB", "100GB", "1TB")')
                     ->end()
                 ->end()
                 ->arrayNode('tables')->prototype('scalar')->end()->end()

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -16,7 +16,7 @@ use Psr\Log\LoggerInterface;
 
 class SapiMigrate implements MigrateInterface
 {
-    private const LARGE_GCS_TABLE_SIZE = 50*1000*1000*1000; // 50 GB
+    private const DEFAULT_LARGE_GCS_TABLE_SIZE = 50*1000*1000*1000; // 50 GB
     private StorageModifier $storageModifier;
     private MigrateGcsLargeTable $migrateGcsLargeTable;
 
@@ -222,9 +222,10 @@ class SapiMigrate implements MigrateInterface
             ->setFederationToken(true)
             ->setFileName($tableIdStr);
         $tableSize = $sourceFileInfo['sizeBytes'];
+        $largeTableThreshold = $config->getChunkSizeBytes() ?? self::DEFAULT_LARGE_GCS_TABLE_SIZE;
         if ($sourceFileInfo['provider'] === 'gcp' &&
             $sourceFileInfo['isSliced'] === true &&
-            $tableSize > self::LARGE_GCS_TABLE_SIZE
+            $tableSize > $largeTableThreshold
         ) {
             $this->migrateGcsLargeTable->migrate(
                 $sourceFileId,
@@ -281,9 +282,10 @@ class SapiMigrate implements MigrateInterface
             ->setFileName($sourceTableInfo['id'])
         ;
         $tableSize = $sourceFileInfo['sizeBytes'];
+        $largeTableThreshold = $config->getChunkSizeBytes() ?? self::DEFAULT_LARGE_GCS_TABLE_SIZE;
         if ($sourceFileInfo['provider'] === 'gcp' &&
             $sourceFileInfo['isSliced'] === true &&
-            $tableSize > self::LARGE_GCS_TABLE_SIZE
+            $tableSize > $largeTableThreshold
         ) {
             $this->migrateGcsLargeTable->migrate(
                 $sourceFileId,


### PR DESCRIPTION
## Summary

Adds a new `chunkSize` configuration parameter that allows users to configure the threshold for when tables are migrated using the chunked GCS large table migration path.

**Background:** When using `preserveTimestamp: true` with large tables (>50GB), the chunked migration uses incremental imports which trigger a BigQuery bug: "Update item _timestamp assigned more than once". By setting a higher `chunkSize` value (e.g., `"500GB"`), users can force tables to use the regular (non-chunked) migration path which uses full imports instead of incremental imports.

**Changes:**
- Added `chunkSize` parameter to ConfigDefinition with format validation (supports MB, GB, TB formats, e.g., "10MB", "100GB", "1TB")
- Added `getChunkSizeBytes()` method in Config.php to parse the parameter and convert to bytes
- Updated both migration code paths in SapiMigrate.php to use the configurable threshold
- Renamed constant from `LARGE_GCS_TABLE_SIZE` to `DEFAULT_LARGE_GCS_TABLE_SIZE`

## Updates since last revision

- Extended `chunkSize` format to support MB, GB, and TB units (previously only GB)
- Examples: `"10MB"`, `"100GB"`, `"1TB"` are all valid values

## Review & Testing Checklist for Human

- [ ] **Verify byte calculation is intentional**: Uses decimal multipliers (1000^3 for GB, not 1024^3) - this matches the original constant but confirm this is the expected behavior
- [ ] **Test with actual large table migration**: Run a migration with `preserveTimestamp: true` and a table that would normally trigger the chunked path, using a high `chunkSize` to verify it bypasses chunking
- [ ] **No unit tests added**: Consider whether tests should be required for the new parameter parsing and validation logic

**Recommended test plan:**
1. Configure the component with `"chunkSize": "500GB"` and `"preserveTimestamp": true`
2. Migrate a table between 50-500GB that previously failed with the "assigned more than once" error
3. Verify the migration completes successfully using the non-chunked path

### Notes

Requested by: Vojta Tuma (@yustme)
Link to Devin run: https://app.devin.ai/sessions/b726904713e341cab776b15d73a18d9a

## Release Notes
**Justification, description**

Adds configurable `chunkSize` parameter to work around BigQuery timestamp handling bug in large table migrations.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low risk - adds optional parameter with backward-compatible default behavior (50GB threshold unchanged when parameter not set)

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A