### PR TITLE
feat: skip READER_* schemas during database mode migration [AJDA-2202]

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ In Database mode, the application migrates data directly between databases, whic
 - Both Snowflake accounts must belong to the same organization.
 - The Snowflake user must have the `ACCOUNTADMIN` role.
 
+The following schemas are automatically excluded from migration:
+- `INFORMATION_SCHEMA` and `PUBLIC` (system schemas)
+- `READER_*` schemas (temporary read-only workspace schemas used for Snowflake sharing)
+- `WORKSPACE*` schemas (unless explicitly included via configuration)
+
 To enable replication, the source Snowflake account must first [allow replication](https://docs.snowflake.com/user-guide/account-replication-config#prerequisite-enable-replication-for-accounts-in-the-organization) and then execute the following SQL statement:
 ```sql
 ALTER DATABASE {{SOURCE_DATABASE_NAME}} ENABLE REPLICATION TO ACCOUNTS {{DESTINATION_ACCOUNT_REGION}}.{{DESTINATION_ACCOUNT_NAME}};

--- a/src/Strategy/DatabaseMigrate.php
+++ b/src/Strategy/DatabaseMigrate.php
@@ -100,6 +100,10 @@ class DatabaseMigrate implements MigrateInterface
             if (in_array($schemaName, self::SKIP_CLONE_SCHEMAS, true)) {
                 continue;
             }
+            if (preg_match('/^READER_/', $schemaName)) {
+                $this->logger->info(sprintf('Skipping reader schema "%s".', $schemaName));
+                continue;
+            }
             if (preg_match('/^(\d+_)?WORKSPACE/', $schemaName)
                 && !in_array($schemaName, $config->getIncludedWorkspaceSchemas())) {
                 continue;


### PR DESCRIPTION
## Summary

Adds filtering logic to skip `READER_*` schemas during database mode migration. These are temporary, read-only workspace schemas (like `READER_SCHEMA_{projectId}_{workspaceId}`) that are part of Keboola's reader workspace infrastructure and tied to Snowflake sharing features. They shouldn't be migrated between projects since they're environment-specific.

The implementation adds a regex check `/^READER_/` in `DatabaseMigrate::migrateData()` after the existing `SKIP_CLONE_SCHEMAS` check but before workspace filtering, following the existing pattern for schema exclusion.

### Notes

No unit tests were added for this filtering logic. The change is minimal and follows existing patterns, but manual testing with actual READER_* schemas is recommended.

**Linear ticket:** AJDA-2202

**Link to Devin run:** https://app.devin.ai/sessions/3a889643fc3f420aabbb8df80fffde37
**Requested by:** Ondřej Jodas (@ondrajodas)

## Release Notes
**Justification, description**

Skip READER_* schemas during database mode migration to prevent migrating environment-specific Snowflake sharing schemas.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Low risk - adds additional filtering to exclude schemas that should not be migrated. Does not affect existing migration behavior for valid schemas.

**Deployment Plan**

N/A

**Rollback Plan**

N/A

**Post-Release Support Plan**

N/A