### PR TITLE
feat: replace PHP timestamp conversion with DuckDB SQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,8 @@ RUN pecl install xdebug \
 # Install DuckDB CLI
 ARG DUCKDB_VERSION=1.1.3
 ADD https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip /tmp/duckdb.zip
-RUN unzip /tmp/duckdb.zip -d /usr/local/bin/ && rm /tmp/duckdb.zip && chmod +x /usr/local/bin/duckdb
+RUN unzip /tmp/duckdb.zip -d /usr/local/bin/ && rm /tmp/duckdb.zip && chmod +x /usr/local/bin/duckdb \
+    && duckdb -c "INSTALL icu;"
 
 ## Composer - deps always cached unless changed
 # First copy only composer files

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,8 @@ RUN pecl install xdebug \
 ARG DUCKDB_VERSION=1.1.3
 ADD https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip /tmp/duckdb.zip
 RUN unzip /tmp/duckdb.zip -d /usr/local/bin/ && rm /tmp/duckdb.zip && chmod +x /usr/local/bin/duckdb \
-    && duckdb -c "INSTALL icu;"
+    && duckdb -c "INSTALL icu;" \
+    && mkdir -p /.duckdb && cp -r /root/.duckdb/* /.duckdb/ && chmod -R 777 /.duckdb
 
 ## Composer - deps always cached unless changed
 # First copy only composer files

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,11 @@ EOF
 RUN pecl install xdebug \
     && docker-php-ext-enable xdebug
 
+# Install DuckDB CLI
+ARG DUCKDB_VERSION=1.1.3
+ADD https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip /tmp/duckdb.zip
+RUN unzip /tmp/duckdb.zip -d /usr/local/bin/ && rm /tmp/duckdb.zip && chmod +x /usr/local/bin/duckdb
+
 ## Composer - deps always cached unless changed
 # First copy only composer files
 COPY composer.* /code/

--- a/src/Component.php
+++ b/src/Component.php
@@ -37,6 +37,7 @@ class Component extends BaseComponent
                     $targetSapiClient,
                     $this->getLogger(),
                     $this->getConfig()->isDryRun(),
+                    $this->getConfig()->getSourceTimezone(),
                 );
                 break;
             case 'database':

--- a/src/Config.php
+++ b/src/Config.php
@@ -248,4 +248,9 @@ class Config extends BaseConfig
     {
         return (bool) $this->getValue(['parameters', 'migrateData'], true);
     }
+
+    public function getParallelism(): int
+    {
+        return $this->getIntValue(['parameters', 'parallelism'], 1);
+    }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -253,4 +253,11 @@ class Config extends BaseConfig
     {
         return $this->getIntValue(['parameters', 'parallelism'], 1);
     }
+
+    public function getSourceTimezone(): string
+    {
+        /** @var string $value */
+        $value = $this->getValue(['parameters', 'sourceTimezone'], 'America/Los_Angeles');
+        return $value;
+    }
 }

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -26,6 +26,7 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->scalarNode('#sourceKbcToken')->isRequired()->cannotBeEmpty()->end()
                 ->arrayNode('includeWorkspaceSchemas')->prototype('scalar')->end()->end()
                 ->booleanNode('preserveTimestamp')->defaultFalse()->end()
+                ->scalarNode('sourceTimezone')->defaultValue('America/Los_Angeles')->end()
                 ->arrayNode('tables')->prototype('scalar')->end()->end()
                 ->booleanNode('migrateData')->defaultTrue()->end()
                 ->arrayNode('replica')

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -19,6 +19,7 @@ class ConfigDefinition extends BaseConfigDefinition
             ->children()
                 ->enumNode('mode')->values(['sapi', 'database'])->defaultValue('sapi')->end()
                 ->booleanNode('dryRun')->defaultFalse()->end()
+                ->integerNode('parallelism')->defaultValue(1)->min(1)->max(10)->end()
                 ->booleanNode('isSourceByodb')->defaultFalse()->end()
                 ->scalarNode('sourceByodb')->end()
                 ->scalarNode('sourceKbcUrl')->isRequired()->cannotBeEmpty()->end()

--- a/src/StorageModifier.php
+++ b/src/StorageModifier.php
@@ -5,20 +5,26 @@ declare(strict_types=1);
 namespace Keboola\AppProjectMigrateLargeTables;
 
 use Keboola\Csv\CsvFile;
+use Keboola\Datatype\Definition\Bigquery;
+use Keboola\Datatype\Definition\Snowflake;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Exception as StorageApiException;
 use Keboola\StorageApi\Metadata;
 use Keboola\StorageApi\Options\Metadata\TableMetadataUpdateOptions;
 use Keboola\Temp\Temp;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class StorageModifier
 {
     private Temp $tmp;
+    private LoggerInterface $logger;
 
-    public function __construct(readonly Client $client)
+    public function __construct(readonly Client $client, ?LoggerInterface $logger = null)
     {
         $this->tmp = new Temp();
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function createBucket(string $schemaName): void
@@ -59,6 +65,8 @@ class StorageModifier
 
     private function createTypedTable(array $tableInfo): void
     {
+        $sourceBackendType = $tableInfo['bucket']['backend'];
+        $destinationBackendType = $this->getDestinationBucketBackend($tableInfo['bucket']['id']);
         $columns = [];
         foreach ($tableInfo['columns'] as $column) {
             $columns[$column] = [];
@@ -72,18 +80,38 @@ class StorageModifier
                 }
                 $columnMetadata[$metadata['key']] = $metadata['value'];
             }
-
-            $definition = [
-                'type' => $columnMetadata['KBC.datatype.type'],
-                'nullable' => $columnMetadata['KBC.datatype.nullable'] === '1',
-            ];
-            if (isset($columnMetadata['KBC.datatype.length'])) {
-                $definition['length'] = $columnMetadata['KBC.datatype.length'];
+            if ($destinationBackendType !== $sourceBackendType) {
+                $sourceBaseType = $this->getBaseType(
+                    $sourceBackendType,
+                    $columnMetadata['KBC.datatype.type'],
+                );
+                switch ($destinationBackendType) {
+                    case 'snowflake':
+                        $definition = (Snowflake::getDefinitionForBasetype((string) $sourceBaseType))->toArray();
+                        break;
+                    case 'bigquery':
+                        $definition = (Bigquery::getDefinitionForBasetype((string) $sourceBaseType))->toArray();
+                        break;
+                    default:
+                        $this->logger->warning(sprintf(
+                            'Unsupported destination backend type "%s" for cross-backend type conversion',
+                            $destinationBackendType,
+                        ));
+                        continue 2;
+                }
+                $definition['nullable'] = $columnMetadata['KBC.datatype.nullable'] === '1';
+            } else {
+                $definition = [
+                    'type' => $columnMetadata['KBC.datatype.type'],
+                    'nullable' => $columnMetadata['KBC.datatype.nullable'] === '1',
+                ];
+                if (isset($columnMetadata['KBC.datatype.length'])) {
+                    $definition['length'] = $columnMetadata['KBC.datatype.length'];
+                }
+                if (isset($columnMetadata['KBC.datatype.default'])) {
+                    $definition['default'] = $columnMetadata['KBC.datatype.default'];
+                }
             }
-            if (isset($columnMetadata['KBC.datatype.default'])) {
-                $definition['default'] = $columnMetadata['KBC.datatype.default'];
-            }
-
             $columns[$columnName] = [
                 'name' => $columnName,
                 'definition' => $definition,
@@ -167,5 +195,23 @@ class StorageModifier
             ];
         }
         return $result;
+    }
+
+    private function getDestinationBucketBackend(string $bucketId): string
+    {
+        $bucket = $this->client->getBucket($bucketId);
+        return $bucket['backend'];
+    }
+
+    private function getBaseType(string $backend, string $originalType): ?string
+    {
+        switch ($backend) {
+            case 'snowflake':
+                return (new Snowflake($originalType))->getBasetype();
+            case 'bigquery':
+                return (new Bigquery($originalType))->getBasetype();
+            default:
+                return null;
+        }
     }
 }

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -242,7 +242,7 @@ class SapiMigrate implements MigrateInterface
             if ($this->dryRun === false) {
                 $this->logger->info(sprintf('Downloading table %s', $tableIdStr));
                 $slices = $this->sourceClient->downloadSlicedFile($sourceFileId, $tmp->getTmpFolder());
-                $this->convertTimestampsInSlices($tableInfo, $slices);
+                $this->convertTimestampsInSlices($tableInfo, $slices, $config->preserveTimestamp());
                 $this->logger->info(sprintf('Uploading table %s', $tableIdStr));
                 $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);
             } else {
@@ -255,7 +255,7 @@ class SapiMigrate implements MigrateInterface
             if ($this->dryRun === false) {
                 $this->logger->info(sprintf('Downloading table %s', $tableIdStr));
                 $this->sourceClient->downloadFile($sourceFileId, $fileName);
-                $this->convertTimestampsInFile($tableInfo, $fileName);
+                $this->convertTimestampsInFile($tableInfo, $fileName, $config->preserveTimestamp());
                 $this->logger->info(sprintf('Uploading table %s', $tableIdStr));
                 $destinationFileId = $this->targetClient->uploadFile($fileName, $optionUploadedFile);
             } else {
@@ -304,7 +304,7 @@ class SapiMigrate implements MigrateInterface
             if ($this->dryRun === false) {
                 $this->logger->info(sprintf('Downloading table %s', $sourceTableInfo['id']));
                 $slices = $this->sourceClient->downloadSlicedFile($sourceFileId, $tmp->getTmpFolder());
-                $this->convertTimestampsInSlices($sourceTableInfo, $slices);
+                $this->convertTimestampsInSlices($sourceTableInfo, $slices, $config->preserveTimestamp());
 
                 $this->logger->info(sprintf('Uploading table %s', $sourceTableInfo['id']));
                 $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);
@@ -318,7 +318,7 @@ class SapiMigrate implements MigrateInterface
             if ($this->dryRun === false) {
                 $this->logger->info(sprintf('Downloading table %s', $sourceTableInfo['id']));
                 $this->sourceClient->downloadFile($sourceFileId, $fileName);
-                $this->convertTimestampsInFile($sourceTableInfo, $fileName);
+                $this->convertTimestampsInFile($sourceTableInfo, $fileName, $config->preserveTimestamp());
 
                 $this->logger->info(sprintf('Uploading table %s', $sourceTableInfo['id']));
                 $destinationFileId = $this->targetClient->uploadFile($fileName, $optionUploadedFile);
@@ -380,7 +380,7 @@ class SapiMigrate implements MigrateInterface
     /**
      * @param array<string, mixed> $tableInfo
      */
-    private function createTimestampConverter(array $tableInfo): TimestampConverter
+    private function createTimestampConverter(array $tableInfo, bool $preserveTimestamp = false): TimestampConverter
     {
         /** @var string[] $columns */
         $columns = $tableInfo['columns'];
@@ -391,6 +391,7 @@ class SapiMigrate implements MigrateInterface
             $columnMetadata,
             $this->sourceTimezone,
             $this->logger,
+            $preserveTimestamp,
         );
     }
 
@@ -398,9 +399,9 @@ class SapiMigrate implements MigrateInterface
      * @param array<string, mixed> $tableInfo
      * @param string[] $slicePaths
      */
-    private function convertTimestampsInSlices(array $tableInfo, array $slicePaths): void
+    private function convertTimestampsInSlices(array $tableInfo, array $slicePaths, bool $preserveTimestamp = false): void
     {
-        $converter = $this->createTimestampConverter($tableInfo);
+        $converter = $this->createTimestampConverter($tableInfo, $preserveTimestamp);
         if ($converter->hasTimestampColumns()) {
             assert(is_string($tableInfo['id']));
             $this->logger->info(sprintf('Converting timezone timestamps to UTC for table %s', $tableInfo['id']));
@@ -411,9 +412,9 @@ class SapiMigrate implements MigrateInterface
     /**
      * @param array<string, mixed> $tableInfo
      */
-    private function convertTimestampsInFile(array $tableInfo, string $filePath): void
+    private function convertTimestampsInFile(array $tableInfo, string $filePath, bool $preserveTimestamp = false): void
     {
-        $converter = $this->createTimestampConverter($tableInfo);
+        $converter = $this->createTimestampConverter($tableInfo, $preserveTimestamp);
         if ($converter->hasTimestampColumns()) {
             assert(is_string($tableInfo['id']));
             $this->logger->info(sprintf('Converting timezone timestamps to UTC for table %s', $tableInfo['id']));

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -8,6 +8,7 @@ use Keboola\AppProjectMigrateLargeTables\Config;
 use Keboola\AppProjectMigrateLargeTables\MigrateInterface;
 use Keboola\AppProjectMigrateLargeTables\StorageModifier;
 use Keboola\AppProjectMigrateLargeTables\Strategy\SapiMigrate\MigrateGcsLargeTable;
+use Keboola\AppProjectMigrateLargeTables\TimestampConverter;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Options\FileUploadOptions;
@@ -28,6 +29,7 @@ class SapiMigrate implements MigrateInterface
         private readonly Client $targetClient,
         private readonly LoggerInterface $logger,
         private readonly bool $dryRun = false,
+        private readonly string $sourceTimezone = 'America/Los_Angeles',
     ) {
         $this->storageModifier = new StorageModifier($this->targetClient);
         $this->migrateGcsLargeTable = new MigrateGcsLargeTable(
@@ -35,6 +37,7 @@ class SapiMigrate implements MigrateInterface
             $this->targetClient,
             $this->logger,
             $this->dryRun,
+            $this->sourceTimezone,
         );
     }
 
@@ -239,6 +242,7 @@ class SapiMigrate implements MigrateInterface
             if ($this->dryRun === false) {
                 $this->logger->info(sprintf('Downloading table %s', $tableIdStr));
                 $slices = $this->sourceClient->downloadSlicedFile($sourceFileId, $tmp->getTmpFolder());
+                $this->convertTimestampsInSlices($tableInfo, $slices);
                 $this->logger->info(sprintf('Uploading table %s', $tableIdStr));
                 $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);
             } else {
@@ -251,6 +255,7 @@ class SapiMigrate implements MigrateInterface
             if ($this->dryRun === false) {
                 $this->logger->info(sprintf('Downloading table %s', $tableIdStr));
                 $this->sourceClient->downloadFile($sourceFileId, $fileName);
+                $this->convertTimestampsInFile($tableInfo, $fileName);
                 $this->logger->info(sprintf('Uploading table %s', $tableIdStr));
                 $destinationFileId = $this->targetClient->uploadFile($fileName, $optionUploadedFile);
             } else {
@@ -299,6 +304,7 @@ class SapiMigrate implements MigrateInterface
             if ($this->dryRun === false) {
                 $this->logger->info(sprintf('Downloading table %s', $sourceTableInfo['id']));
                 $slices = $this->sourceClient->downloadSlicedFile($sourceFileId, $tmp->getTmpFolder());
+                $this->convertTimestampsInSlices($sourceTableInfo, $slices);
 
                 $this->logger->info(sprintf('Uploading table %s', $sourceTableInfo['id']));
                 $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);
@@ -312,6 +318,7 @@ class SapiMigrate implements MigrateInterface
             if ($this->dryRun === false) {
                 $this->logger->info(sprintf('Downloading table %s', $sourceTableInfo['id']));
                 $this->sourceClient->downloadFile($sourceFileId, $fileName);
+                $this->convertTimestampsInFile($sourceTableInfo, $fileName);
 
                 $this->logger->info(sprintf('Uploading table %s', $sourceTableInfo['id']));
                 $destinationFileId = $this->targetClient->uploadFile($fileName, $optionUploadedFile);
@@ -368,5 +375,49 @@ class SapiMigrate implements MigrateInterface
             );
         }
         return $listTables;
+    }
+
+    /**
+     * @param array<string, mixed> $tableInfo
+     */
+    private function createTimestampConverter(array $tableInfo): TimestampConverter
+    {
+        /** @var string[] $columns */
+        $columns = $tableInfo['columns'];
+        /** @var array<string, array<int, array<string, string>>> $columnMetadata */
+        $columnMetadata = $tableInfo['columnMetadata'] ?? [];
+        return new TimestampConverter(
+            $columns,
+            $columnMetadata,
+            $this->sourceTimezone,
+            $this->logger,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $tableInfo
+     * @param string[] $slicePaths
+     */
+    private function convertTimestampsInSlices(array $tableInfo, array $slicePaths): void
+    {
+        $converter = $this->createTimestampConverter($tableInfo);
+        if ($converter->hasTimestampColumns()) {
+            assert(is_string($tableInfo['id']));
+            $this->logger->info(sprintf('Converting timezone timestamps to UTC for table %s', $tableInfo['id']));
+            $converter->processGzippedSlices($slicePaths);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $tableInfo
+     */
+    private function convertTimestampsInFile(array $tableInfo, string $filePath): void
+    {
+        $converter = $this->createTimestampConverter($tableInfo);
+        if ($converter->hasTimestampColumns()) {
+            assert(is_string($tableInfo['id']));
+            $this->logger->info(sprintf('Converting timezone timestamps to UTC for table %s', $tableInfo['id']));
+            $converter->processGzippedFile($filePath);
+        }
     }
 }

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -399,8 +399,11 @@ class SapiMigrate implements MigrateInterface
      * @param array<string, mixed> $tableInfo
      * @param string[] $slicePaths
      */
-    private function convertTimestampsInSlices(array $tableInfo, array $slicePaths, bool $preserveTimestamp = false): void
-    {
+    private function convertTimestampsInSlices(
+        array $tableInfo,
+        array $slicePaths,
+        bool $preserveTimestamp = false,
+    ): void {
         $converter = $this->createTimestampConverter($tableInfo, $preserveTimestamp);
         if ($converter->hasTimestampColumns()) {
             assert(is_string($tableInfo['id']));

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -40,6 +40,25 @@ class SapiMigrate implements MigrateInterface
 
     public function migrate(Config $config): void
     {
+        $parallelism = $config->getParallelism();
+        $tablesToMigrate = $this->prepareTablesToMigrate($config);
+        if ($parallelism <= 1) {
+            foreach ($tablesToMigrate as $tableInfo) {
+                $this->migrateTable($tableInfo, $config);
+            }
+        } else {
+            $this->logger->info(sprintf('Migrating tables with parallelism: %d', $parallelism));
+            $this->migrateTablesInParallel($tablesToMigrate, $config, $parallelism);
+        }
+    }
+
+    /**
+     * Prepares tables for migration by validating them and creating buckets/tables as needed.
+     * @return array<array<string, mixed>> Array of table info arrays ready for migration
+     */
+    private function prepareTablesToMigrate(Config $config): array
+    {
+        $tablesToMigrate = [];
         foreach ($config->getMigrateTables() ?: $this->getAllTables() as $tableId) {
             try {
                 $tableInfo = $this->sourceClient->getTable($tableId);
@@ -55,12 +74,10 @@ class SapiMigrate implements MigrateInterface
                 $this->logger->warning(sprintf('Skipping table %s (sys bucket)', $tableInfo['id']));
                 continue;
             }
-
             if ($tableInfo['isAlias']) {
                 $this->logger->warning(sprintf('Skipping table %s (alias)', $tableInfo['id']));
                 continue;
             }
-
             if (!in_array($tableInfo['bucket']['id'], $this->bucketsExist) &&
                 !$this->targetClient->bucketExists($tableInfo['bucket']['id'])) {
                 if ($this->dryRun) {
@@ -68,11 +85,9 @@ class SapiMigrate implements MigrateInterface
                 } else {
                     $this->logger->info(sprintf('Creating bucket %s', $tableInfo['bucket']['id']));
                     $this->bucketsExist[] = $tableInfo['bucket']['id'];
-
                     $this->storageModifier->createBucket($tableInfo['bucket']['id']);
                 }
             }
-
             if (!$this->targetClient->tableExists($tableId)) {
                 if ($this->dryRun) {
                     $this->logger->info(sprintf('[dry-run] Creating table %s', $tableInfo['id']));
@@ -81,9 +96,171 @@ class SapiMigrate implements MigrateInterface
                     $this->storageModifier->createTable($tableInfo);
                 }
             }
-
-            $this->migrateTable($tableInfo, $config);
+            $tablesToMigrate[] = $tableInfo;
         }
+        return $tablesToMigrate;
+    }
+
+    /**
+     * Migrates tables in parallel batches.
+     * @param array<array<string, mixed>> $tablesToMigrate
+     */
+    private function migrateTablesInParallel(array $tablesToMigrate, Config $config, int $parallelism): void
+    {
+        $batches = array_chunk($tablesToMigrate, max(1, $parallelism));
+        foreach ($batches as $batchIndex => $batch) {
+            $this->logger->info(sprintf(
+                'Processing batch %d/%d (%d tables)',
+                $batchIndex + 1,
+                count($batches),
+                count($batch),
+            ));
+            $this->processBatch($batch, $config);
+        }
+    }
+
+    /**
+     * Processes a batch of tables in parallel.
+     * @param array<array<string, mixed>> $batch
+     */
+    private function processBatch(array $batch, Config $config): void
+    {
+        $exportJobs = [];
+        foreach ($batch as $tableInfo) {
+            assert(is_string($tableInfo['id']));
+            $tableId = $tableInfo['id'];
+            $this->logger->info(sprintf('Queueing export for table %s', $tableId));
+            $jobId = $this->sourceClient->queueTableExport($tableId, [
+                'gzip' => true,
+                'includeInternalTimestamp' => $config->preserveTimestamp(),
+            ]);
+            $exportJobs[$tableId] = [
+                'jobId' => $jobId,
+                'tableInfo' => $tableInfo,
+            ];
+        }
+        $exportResults = [];
+        foreach ($exportJobs as $tableId => $jobData) {
+            $this->logger->info(sprintf('Waiting for export job for table %s', $tableId));
+            $job = $this->sourceClient->waitForJob($jobData['jobId']);
+            if ($job === null || $job['status'] !== 'success') {
+                $errorMessage = $job['error']['message'] ?? 'Unknown error';
+                $this->logger->warning(sprintf(
+                    'Export failed for table %s: %s',
+                    $tableId,
+                    $errorMessage,
+                ));
+                continue;
+            }
+            $results = $job['results'];
+            assert(is_array($results) && is_array($results['file']));
+            $file = $results['file'];
+            assert(isset($file['id']) && is_int($file['id']));
+            $fileId = $file['id'];
+            $exportResults[$tableId] = [
+                'tableInfo' => $jobData['tableInfo'],
+                'fileId' => $fileId,
+            ];
+        }
+        $uploadResults = [];
+        foreach ($exportResults as $tableId => $exportData) {
+            $result = $this->downloadAndUpload($exportData['tableInfo'], $exportData['fileId'], $config);
+            if ($result !== null) {
+                $uploadResults[$tableId] = [
+                    'tableInfo' => $exportData['tableInfo'],
+                    'destinationFileId' => $result,
+                ];
+            }
+        }
+        $importJobs = [];
+        foreach ($uploadResults as $tableId => $uploadData) {
+            if ($this->dryRun) {
+                assert(is_string($uploadData['tableInfo']['name']));
+                $tableName = $uploadData['tableInfo']['name'];
+                $this->logger->info(sprintf('[dry-run] Import data to table "%s"', $tableName));
+                continue;
+            }
+            $this->logger->info(sprintf('Queueing import for table %s', $tableId));
+            $jobId = $this->targetClient->queueTableImport(
+                $tableId,
+                [
+                    'name' => $uploadData['tableInfo']['name'],
+                    'dataFileId' => $uploadData['destinationFileId'],
+                    'columns' => $uploadData['tableInfo']['columns'],
+                    'useTimestampFromDataFile' => $config->preserveTimestamp(),
+                ],
+            );
+            $importJobs[$tableId] = $jobId;
+        }
+        foreach ($importJobs as $tableId => $jobId) {
+            $this->logger->info(sprintf('Waiting for import job for table %s', $tableId));
+            $job = $this->targetClient->waitForJob($jobId);
+            if ($job === null || $job['status'] !== 'success') {
+                $errorMessage = $job['error']['message'] ?? 'Unknown error';
+                $this->logger->warning(sprintf(
+                    'Import failed for table %s: %s',
+                    $tableId,
+                    $errorMessage,
+                ));
+            }
+        }
+    }
+
+    /**
+     * Downloads file from source and uploads to target.
+     * @param array<string, mixed> $tableInfo
+     * @return int|null The destination file ID, or null if dry run or large GCS table
+     */
+    private function downloadAndUpload(array $tableInfo, int $sourceFileId, Config $config): ?int
+    {
+        $sourceFileInfo = $this->sourceClient->getFile($sourceFileId);
+        $tmp = new Temp();
+        $optionUploadedFile = new FileUploadOptions();
+        assert(is_string($tableInfo['id']));
+        $tableIdStr = $tableInfo['id'];
+        $optionUploadedFile
+            ->setFederationToken(true)
+            ->setFileName($tableIdStr);
+        $tableSize = $sourceFileInfo['sizeBytes'];
+        if ($sourceFileInfo['provider'] === 'gcp' &&
+            $sourceFileInfo['isSliced'] === true &&
+            $tableSize > self::LARGE_GCS_TABLE_SIZE
+        ) {
+            $this->migrateGcsLargeTable->migrate(
+                $sourceFileId,
+                $tableInfo,
+                $config->preserveTimestamp(),
+                $tmp,
+            );
+            $tmp->remove();
+            return null;
+        } elseif ($sourceFileInfo['isSliced'] === true) {
+            $optionUploadedFile->setIsSliced(true);
+            if ($this->dryRun === false) {
+                $this->logger->info(sprintf('Downloading table %s', $tableIdStr));
+                $slices = $this->sourceClient->downloadSlicedFile($sourceFileId, $tmp->getTmpFolder());
+                $this->logger->info(sprintf('Uploading table %s', $tableIdStr));
+                $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);
+            } else {
+                $this->logger->info(sprintf('[dry-run] Migrate table %s', $tableIdStr));
+                $tmp->remove();
+                return null;
+            }
+        } else {
+            $fileName = $tmp->getTmpFolder() . '/' . $sourceFileInfo['name'];
+            if ($this->dryRun === false) {
+                $this->logger->info(sprintf('Downloading table %s', $tableIdStr));
+                $this->sourceClient->downloadFile($sourceFileId, $fileName);
+                $this->logger->info(sprintf('Uploading table %s', $tableIdStr));
+                $destinationFileId = $this->targetClient->uploadFile($fileName, $optionUploadedFile);
+            } else {
+                $this->logger->info(sprintf('[dry-run] Uploading table %s', $tableIdStr));
+                $tmp->remove();
+                return null;
+            }
+        }
+        $tmp->remove();
+        return $destinationFileId;
     }
 
     private function migrateTable(array $sourceTableInfo, Config $config): void

--- a/src/Strategy/SapiMigrate/MigrateGcsLargeTable.php
+++ b/src/Strategy/SapiMigrate/MigrateGcsLargeTable.php
@@ -83,6 +83,7 @@ class MigrateGcsLargeTable
                 $tableInfo['columnMetadata'] ?? [],
                 $this->sourceTimezone,
                 $this->logger,
+                $preserveTimestamp,
             );
             if ($converter->hasTimestampColumns()) {
                 $this->logger->info(sprintf(

--- a/src/Strategy/SapiMigrate/MigrateGcsLargeTable.php
+++ b/src/Strategy/SapiMigrate/MigrateGcsLargeTable.php
@@ -7,6 +7,7 @@ namespace Keboola\AppProjectMigrateLargeTables\Strategy\SapiMigrate;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Cloud\Storage\StorageClient as GoogleStorageClient;
 use GuzzleHttp\Utils;
+use Keboola\AppProjectMigrateLargeTables\TimestampConverter;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\StorageApi\Options\GetFileOptions;
@@ -23,6 +24,7 @@ class MigrateGcsLargeTable
         private readonly Client $targetClient,
         private readonly LoggerInterface $logger,
         private readonly bool $dryRun = false,
+        private readonly string $sourceTimezone = 'America/Los_Angeles',
     ) {
     }
 
@@ -74,6 +76,22 @@ class MigrateGcsLargeTable
                 );
                 $blobPath = explode($sprintf, $entry['url']);
                 $retBucket->object($blobPath[1])->downloadToFile($destinationFile);
+            }
+
+            $converter = new TimestampConverter(
+                $tableInfo['columns'],
+                $tableInfo['columnMetadata'] ?? [],
+                $this->sourceTimezone,
+                $this->logger,
+            );
+            if ($converter->hasTimestampColumns()) {
+                $this->logger->info(sprintf(
+                    'Converting timezone timestamps to UTC for table %s (chunk %d/%d)',
+                    $tableInfo['id'],
+                    $chunkKey + 1,
+                    count($chunks),
+                ));
+                $converter->processGzippedSlices($slices);
             }
 
             $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -8,6 +8,7 @@ use Psr\Log\LoggerInterface;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RuntimeException;
+use SplFileInfo;
 
 class TimestampConverter
 {
@@ -195,6 +196,7 @@ class TimestampConverter
             RecursiveIteratorIterator::SELF_FIRST,
         );
         foreach ($iterator as $item) {
+            assert($item instanceof SplFileInfo);
             $target = $destination . '/' . $iterator->getSubPathname();
             if ($item->isDir()) {
                 if (!is_dir($target)) {

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -15,6 +15,7 @@ class TimestampConverter
     ];
 
     private const DUCKDB_BINARY = 'duckdb';
+    private const DUCKDB_EXTENSIONS_SOURCE = '/.duckdb';
 
     /** @var int[] */
     private array $timestampColumnIndices;
@@ -56,16 +57,23 @@ class TimestampConverter
 
         $this->logger->info(sprintf('Running DuckDB timestamp conversion on %s', basename($filePath)));
 
+        $duckDbHome = $this->ensureDuckDbHome();
+
         $descriptorspec = [
             0 => ['pipe', 'r'],
             1 => ['pipe', 'w'],
             2 => ['pipe', 'w'],
         ];
 
+        $env = getenv();
+        $env['HOME'] = $duckDbHome;
+
         $process = proc_open(
             [self::DUCKDB_BINARY, '-c', $sql],
             $descriptorspec,
             $pipes,
+            null,
+            $env,
         );
 
         if (!is_resource($process)) {
@@ -162,6 +170,38 @@ class TimestampConverter
             implode(', ', $columnDefs),
             addcslashes($outputPath, "'"),
         );
+    }
+
+    private function ensureDuckDbHome(): string
+    {
+        $home = sys_get_temp_dir() . '/duckdb-home';
+        $targetDir = $home . '/.duckdb';
+        if (!is_dir($targetDir) && is_dir(self::DUCKDB_EXTENSIONS_SOURCE)) {
+            $this->recursiveCopy(self::DUCKDB_EXTENSIONS_SOURCE, $targetDir);
+        }
+        if (!is_dir($home)) {
+            mkdir($home, 0777, true);
+        }
+        return $home;
+    }
+
+    private function recursiveCopy(string $source, string $destination): void
+    {
+        mkdir($destination, 0777, true);
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($source, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST,
+        );
+        foreach ($iterator as $item) {
+            $target = $destination . '/' . $iterator->getSubPathname();
+            if ($item->isDir()) {
+                if (!is_dir($target)) {
+                    mkdir($target, 0777, true);
+                }
+            } else {
+                copy($item->getPathname(), $target);
+            }
+        }
     }
 
     /**

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AppProjectMigrateLargeTables;
+
+use DateTime;
+use DateTimeZone;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+class TimestampConverter
+{
+    private const TIMESTAMP_TYPES_WITH_TIMEZONE = [
+        'TIMESTAMP_LTZ',
+        'TIMESTAMP_TZ',
+    ];
+
+    /** @var int[] */
+    private array $timestampColumnIndices;
+    private DateTimeZone $sourceTimezone;
+    private DateTimeZone $utcTimezone;
+
+    /**
+     * @param string[] $columns
+     * @param array<string, array<int, array<string, string>>> $columnMetadata
+     */
+    public function __construct(
+        array $columns,
+        array $columnMetadata,
+        string $sourceTimezone,
+        private readonly LoggerInterface $logger,
+    ) {
+        $this->sourceTimezone = new DateTimeZone($sourceTimezone);
+        $this->utcTimezone = new DateTimeZone('UTC');
+        $this->timestampColumnIndices = $this->detectTimestampColumns($columns, $columnMetadata);
+    }
+
+    public function hasTimestampColumns(): bool
+    {
+        return !empty($this->timestampColumnIndices);
+    }
+
+    public function processGzippedFile(string $filePath): void
+    {
+        if (!$this->hasTimestampColumns()) {
+            return;
+        }
+
+        $tempPath = $filePath . '.converting';
+
+        $input = fopen('compress.zlib://' . $filePath, 'r');
+        if ($input === false) {
+            throw new RuntimeException(sprintf('Cannot open file for reading: %s', $filePath));
+        }
+
+        $output = gzopen($tempPath, 'wb');
+        if ($output === false) {
+            fclose($input);
+            throw new RuntimeException(sprintf('Cannot open file for writing: %s', $tempPath));
+        }
+
+        $rowCount = 0;
+        while (($row = fgetcsv($input, 0, ',', '"', '\\')) !== false) {
+            foreach ($this->timestampColumnIndices as $idx) {
+                if (isset($row[$idx]) && $row[$idx] !== '') {
+                    $row[$idx] = $this->convertTimestamp($row[$idx]);
+                }
+            }
+            gzwrite($output, $this->toCsvLine($row));
+            $rowCount++;
+        }
+
+        fclose($input);
+        gzclose($output);
+
+        unlink($filePath);
+        rename($tempPath, $filePath);
+
+        $this->logger->info(sprintf('Converted timestamps to UTC in %d rows', $rowCount));
+    }
+
+    /**
+     * @param string[] $slicePaths
+     */
+    public function processGzippedSlices(array $slicePaths): void
+    {
+        if (!$this->hasTimestampColumns()) {
+            return;
+        }
+
+        foreach ($slicePaths as $path) {
+            $this->processGzippedFile($path);
+        }
+    }
+
+    /**
+     * @param string[] $columns
+     * @param array<string, array<int, array<string, string>>> $columnMetadata
+     * @return int[]
+     */
+    private function detectTimestampColumns(array $columns, array $columnMetadata): array
+    {
+        $indices = [];
+        foreach ($columns as $index => $columnName) {
+            $metadata = $columnMetadata[$columnName] ?? [];
+            foreach ($metadata as $m) {
+                if (($m['provider'] ?? '') === 'storage' && ($m['key'] ?? '') === 'KBC.datatype.type') {
+                    if (in_array(strtoupper($m['value'] ?? ''), self::TIMESTAMP_TYPES_WITH_TIMEZONE, true)) {
+                        $this->logger->info(sprintf(
+                            'Column "%s" (index %d) is %s — will convert to UTC',
+                            $columnName,
+                            $index,
+                            $m['value'],
+                        ));
+                        $indices[] = $index;
+                    }
+                    break;
+                }
+            }
+        }
+        return $indices;
+    }
+
+    private function convertTimestamp(string $value): string
+    {
+        $dt = DateTime::createFromFormat('Y-m-d H:i:s.u', $value, $this->sourceTimezone);
+        if ($dt !== false) {
+            $dt->setTimezone($this->utcTimezone);
+            return $dt->format('Y-m-d H:i:s.u');
+        }
+
+        $dt = DateTime::createFromFormat('Y-m-d H:i:s', $value, $this->sourceTimezone);
+        if ($dt !== false) {
+            $dt->setTimezone($this->utcTimezone);
+            return $dt->format('Y-m-d H:i:s');
+        }
+
+        $this->logger->warning(sprintf('Cannot parse timestamp value: %s', $value));
+        return $value;
+    }
+
+    /**
+     * @param array<int, string|null> $fields
+     */
+    private function toCsvLine(array $fields): string
+    {
+        $parts = [];
+        foreach ($fields as $field) {
+            if ($field === null) {
+                $parts[] = '';
+            } elseif ($this->needsQuoting($field)) {
+                $parts[] = '"' . str_replace('"', '""', $field) . '"';
+            } else {
+                $parts[] = $field;
+            }
+        }
+        return implode(',', $parts) . "\n";
+    }
+
+    private function needsQuoting(string $field): bool
+    {
+        return str_contains($field, ',')
+            || str_contains($field, '"')
+            || str_contains($field, "\n")
+            || str_contains($field, "\r");
+    }
+}

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Keboola\AppProjectMigrateLargeTables;
 
-use DateTime;
-use DateTimeZone;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
@@ -16,10 +14,13 @@ class TimestampConverter
         'TIMESTAMP_TZ',
     ];
 
+    private const DUCKDB_BINARY = 'duckdb';
+
     /** @var int[] */
     private array $timestampColumnIndices;
-    private DateTimeZone $sourceTimezone;
-    private DateTimeZone $utcTimezone;
+    /** @var string[] */
+    private array $columns;
+    private string $sourceTimezoneStr;
 
     /**
      * @param string[] $columns
@@ -31,9 +32,9 @@ class TimestampConverter
         string $sourceTimezone,
         private readonly LoggerInterface $logger,
     ) {
-        $this->sourceTimezone = new DateTimeZone($sourceTimezone);
-        $this->utcTimezone = new DateTimeZone('UTC');
-        $this->timestampColumnIndices = $this->detectTimestampColumns($columns, $columnMetadata);
+        $this->columns = array_values($columns);
+        $this->sourceTimezoneStr = $sourceTimezone;
+        $this->timestampColumnIndices = $this->detectTimestampColumns($this->columns, $columnMetadata);
     }
 
     public function hasTimestampColumns(): bool
@@ -48,36 +49,48 @@ class TimestampConverter
         }
 
         $tempPath = $filePath . '.converting';
+        $sql = $this->buildDuckDbQuery($filePath, $tempPath);
 
-        $input = fopen('compress.zlib://' . $filePath, 'r');
-        if ($input === false) {
-            throw new RuntimeException(sprintf('Cannot open file for reading: %s', $filePath));
+        $this->logger->info(sprintf('Running DuckDB timestamp conversion on %s', basename($filePath)));
+
+        $descriptorspec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open(
+            [self::DUCKDB_BINARY, '-c', $sql],
+            $descriptorspec,
+            $pipes,
+        );
+
+        if (!is_resource($process)) {
+            throw new RuntimeException('Failed to start DuckDB process');
         }
 
-        $output = gzopen($tempPath, 'wb');
-        if ($output === false) {
-            fclose($input);
-            throw new RuntimeException(sprintf('Cannot open file for writing: %s', $tempPath));
+        fclose($pipes[0]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        if ($exitCode !== 0) {
+            throw new RuntimeException(sprintf(
+                'DuckDB timestamp conversion failed (exit code %d): %s',
+                $exitCode,
+                $stderr,
+            ));
         }
 
-        $rowCount = 0;
-        while (($row = fgetcsv($input, 0, ',', '"', '\\')) !== false) {
-            foreach ($this->timestampColumnIndices as $idx) {
-                if (isset($row[$idx]) && $row[$idx] !== '') {
-                    $row[$idx] = $this->convertTimestamp($row[$idx]);
-                }
-            }
-            gzwrite($output, $this->toCsvLine($row));
-            $rowCount++;
+        if (!file_exists($tempPath)) {
+            throw new RuntimeException(sprintf('DuckDB output file not found: %s', $tempPath));
         }
-
-        fclose($input);
-        gzclose($output);
 
         unlink($filePath);
         rename($tempPath, $filePath);
 
-        $this->logger->info(sprintf('Converted timestamps to UTC in %d rows', $rowCount));
+        $this->logger->info('DuckDB timestamp conversion completed');
     }
 
     /**
@@ -94,6 +107,48 @@ class TimestampConverter
         }
     }
 
+    private function buildDuckDbQuery(string $inputPath, string $outputPath): string
+    {
+        $columnCount = count($this->columns);
+
+        $columnDefs = [];
+        for ($i = 0; $i < $columnCount; $i++) {
+            $columnDefs[] = sprintf("'col_%d': 'VARCHAR'", $i);
+        }
+
+        $selectExprs = [];
+        for ($i = 0; $i < $columnCount; $i++) {
+            $colRef = sprintf('"col_%d"', $i);
+            if (in_array($i, $this->timestampColumnIndices, true)) {
+                $selectExprs[] = sprintf(
+                    'CASE WHEN %s IS NOT NULL AND %s != \'\'' .
+                    ' AND TRY_CAST(%s AS TIMESTAMP) IS NOT NULL' .
+                    ' THEN CAST(timezone(\'UTC\', timezone(\'%s\', %s::TIMESTAMP)) AS VARCHAR)' .
+                    ' ELSE %s END',
+                    $colRef,
+                    $colRef,
+                    $colRef,
+                    $this->sourceTimezoneStr,
+                    $colRef,
+                    $colRef,
+                );
+            } else {
+                $selectExprs[] = $colRef;
+            }
+        }
+
+        return sprintf(
+            'COPY (SELECT %s FROM read_csv(\'%s\', header=false, columns={%s},'
+            . ' auto_detect=false, compression=\'gzip\', quote=\'"\', escape=\'"\','
+            . ' null_padding=true, ignore_errors=true))'
+            . ' TO \'%s\' (FORMAT CSV, HEADER false, COMPRESSION \'gzip\', QUOTE \'"\');',
+            implode(', ', $selectExprs),
+            addcslashes($inputPath, "'"),
+            implode(', ', $columnDefs),
+            addcslashes($outputPath, "'"),
+        );
+    }
+
     /**
      * @param string[] $columns
      * @param array<string, array<int, array<string, string>>> $columnMetadata
@@ -108,7 +163,7 @@ class TimestampConverter
                 if (($m['provider'] ?? '') === 'storage' && ($m['key'] ?? '') === 'KBC.datatype.type') {
                     if (in_array(strtoupper($m['value'] ?? ''), self::TIMESTAMP_TYPES_WITH_TIMEZONE, true)) {
                         $this->logger->info(sprintf(
-                            'Column "%s" (index %d) is %s — will convert to UTC',
+                            'Column "%s" (index %d) is %s — will convert to UTC via DuckDB',
                             $columnName,
                             $index,
                             $m['value'],
@@ -120,49 +175,5 @@ class TimestampConverter
             }
         }
         return $indices;
-    }
-
-    private function convertTimestamp(string $value): string
-    {
-        $dt = DateTime::createFromFormat('Y-m-d H:i:s.u', $value, $this->sourceTimezone);
-        if ($dt !== false) {
-            $dt->setTimezone($this->utcTimezone);
-            return $dt->format('Y-m-d H:i:s.u');
-        }
-
-        $dt = DateTime::createFromFormat('Y-m-d H:i:s', $value, $this->sourceTimezone);
-        if ($dt !== false) {
-            $dt->setTimezone($this->utcTimezone);
-            return $dt->format('Y-m-d H:i:s');
-        }
-
-        $this->logger->warning(sprintf('Cannot parse timestamp value: %s', $value));
-        return $value;
-    }
-
-    /**
-     * @param array<int, string|null> $fields
-     */
-    private function toCsvLine(array $fields): string
-    {
-        $parts = [];
-        foreach ($fields as $field) {
-            if ($field === null) {
-                $parts[] = '';
-            } elseif ($this->needsQuoting($field)) {
-                $parts[] = '"' . str_replace('"', '""', $field) . '"';
-            } else {
-                $parts[] = $field;
-            }
-        }
-        return implode(',', $parts) . "\n";
-    }
-
-    private function needsQuoting(string $field): bool
-    {
-        return str_contains($field, ',')
-            || str_contains($field, '"')
-            || str_contains($field, "\n")
-            || str_contains($field, "\r");
     }
 }

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -139,15 +139,31 @@ class TimestampConverter
             if ($dataIndex >= 0 && in_array($dataIndex, $this->timestampColumnIndices, true)) {
                 $selectExprs[] = sprintf(
                     'CASE WHEN %s IS NOT NULL AND %s != \'\'' .
-                    ' AND regexp_matches(%s, \'[+-]\\d{2}:?\\d{2}$\')' .
+                    ' AND regexp_matches(%s, \' [+-]\\d{2}:?\\d{2}$\')' .
                     ' THEN CAST(timezone(\'UTC\',' .
                     ' regexp_replace(' .
                     'regexp_replace(%s, \' ([+-]\\d{2}:?\\d{2})$\', \'\\1\'),' .
                     ' \'([+-])(\\d{2})(\\d{2})$\', \'\\1\\2:\\3\')::TIMESTAMPTZ) AS VARCHAR)' .
                     ' WHEN %s IS NOT NULL AND %s != \'\'' .
+                    ' AND regexp_matches(%s, \'\\d[+-]\\d{2}:\\d{2}$\')' .
+                    ' THEN CAST(timezone(\'UTC\', %s::TIMESTAMPTZ) AS VARCHAR)' .
+                    ' WHEN %s IS NOT NULL AND %s != \'\'' .
+                    ' AND regexp_matches(%s, \'\\d[+-]\\d{4}$\')' .
+                    ' THEN CAST(timezone(\'UTC\',' .
+                    ' regexp_replace(%s, \'([+-])(\\d{2})(\\d{2})$\', \'\\1\\2:\\3\')' .
+                    '::TIMESTAMPTZ) AS VARCHAR)' .
+                    ' WHEN %s IS NOT NULL AND %s != \'\'' .
                     ' AND TRY_CAST(%s AS TIMESTAMP) IS NOT NULL' .
                     ' THEN CAST(timezone(\'UTC\', timezone(\'%s\', %s::TIMESTAMP)) AS VARCHAR)' .
                     ' ELSE %s END',
+                    $colRef,
+                    $colRef,
+                    $colRef,
+                    $colRef,
+                    $colRef,
+                    $colRef,
+                    $colRef,
+                    $colRef,
                     $colRef,
                     $colRef,
                     $colRef,

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -21,6 +21,7 @@ class TimestampConverter
     /** @var string[] */
     private array $columns;
     private string $sourceTimezoneStr;
+    private bool $hasInternalTimestamp;
 
     /**
      * @param string[] $columns
@@ -31,9 +32,11 @@ class TimestampConverter
         array $columnMetadata,
         string $sourceTimezone,
         private readonly LoggerInterface $logger,
+        bool $hasInternalTimestamp = false,
     ) {
         $this->columns = array_values($columns);
         $this->sourceTimezoneStr = $sourceTimezone;
+        $this->hasInternalTimestamp = $hasInternalTimestamp;
         $this->timestampColumnIndices = $this->detectTimestampColumns($this->columns, $columnMetadata);
     }
 
@@ -110,16 +113,19 @@ class TimestampConverter
     private function buildDuckDbQuery(string $inputPath, string $outputPath): string
     {
         $columnCount = count($this->columns);
+        $offset = $this->hasInternalTimestamp ? 1 : 0;
+        $totalCsvColumns = $columnCount + $offset;
 
         $columnDefs = [];
-        for ($i = 0; $i < $columnCount; $i++) {
+        for ($i = 0; $i < $totalCsvColumns; $i++) {
             $columnDefs[] = sprintf("'col_%d': 'VARCHAR'", $i);
         }
 
         $selectExprs = [];
-        for ($i = 0; $i < $columnCount; $i++) {
+        for ($i = 0; $i < $totalCsvColumns; $i++) {
             $colRef = sprintf('"col_%d"', $i);
-            if (in_array($i, $this->timestampColumnIndices, true)) {
+            $dataIndex = $i - $offset;
+            if ($dataIndex >= 0 && in_array($dataIndex, $this->timestampColumnIndices, true)) {
                 $selectExprs[] = sprintf(
                     'CASE WHEN %s IS NOT NULL AND %s != \'\'' .
                     ' AND TRY_CAST(%s AS TIMESTAMP) IS NOT NULL' .

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -139,9 +139,11 @@ class TimestampConverter
             if ($dataIndex >= 0 && in_array($dataIndex, $this->timestampColumnIndices, true)) {
                 $selectExprs[] = sprintf(
                     'CASE WHEN %s IS NOT NULL AND %s != \'\'' .
-                    ' AND regexp_matches(%s, \' [+-]\\d{4}$\')' .
+                    ' AND regexp_matches(%s, \'[+-]\\d{2}:?\\d{2}$\')' .
                     ' THEN CAST(timezone(\'UTC\',' .
-                    ' regexp_replace(%s, \' ([+-])(\\d{2})(\\d{2})$\', \'\\1\\2:\\3\')::TIMESTAMPTZ) AS VARCHAR)' .
+                    ' regexp_replace(' .
+                    'regexp_replace(%s, \' ([+-]\\d{2}:?\\d{2})$\', \'\\1\'),' .
+                    ' \'([+-])(\\d{2})(\\d{2})$\', \'\\1\\2:\\3\')::TIMESTAMPTZ) AS VARCHAR)' .
                     ' WHEN %s IS NOT NULL AND %s != \'\'' .
                     ' AND TRY_CAST(%s AS TIMESTAMP) IS NOT NULL' .
                     ' THEN CAST(timezone(\'UTC\', timezone(\'%s\', %s::TIMESTAMP)) AS VARCHAR)' .

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Keboola\AppProjectMigrateLargeTables;
 
 use Psr\Log\LoggerInterface;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use RuntimeException;
 
 class TimestampConverter
@@ -188,9 +190,9 @@ class TimestampConverter
     private function recursiveCopy(string $source, string $destination): void
     {
         mkdir($destination, 0777, true);
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($source, \RecursiveDirectoryIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::SELF_FIRST,
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST,
         );
         foreach ($iterator as $item) {
             $target = $destination . '/' . $iterator->getSubPathname();

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -152,7 +152,7 @@ class TimestampConverter
         }
 
         return sprintf(
-            'INSTALL icu; LOAD icu;'
+            'LOAD icu;'
             . ' COPY (SELECT %s FROM read_csv(\'%s\', header=false, columns={%s},'
             . ' auto_detect=false, compression=\'gzip\', quote=\'"\', escape=\'"\','
             . ' null_padding=true, ignore_errors=true))'

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -128,9 +128,17 @@ class TimestampConverter
             if ($dataIndex >= 0 && in_array($dataIndex, $this->timestampColumnIndices, true)) {
                 $selectExprs[] = sprintf(
                     'CASE WHEN %s IS NOT NULL AND %s != \'\'' .
+                    ' AND regexp_matches(%s, \' [+-]\\d{4}$\')' .
+                    ' THEN CAST(timezone(\'UTC\',' .
+                    ' regexp_replace(%s, \' ([+-])(\\d{2})(\\d{2})$\', \'\\1\\2:\\3\')::TIMESTAMPTZ) AS VARCHAR)' .
+                    ' WHEN %s IS NOT NULL AND %s != \'\'' .
                     ' AND TRY_CAST(%s AS TIMESTAMP) IS NOT NULL' .
                     ' THEN CAST(timezone(\'UTC\', timezone(\'%s\', %s::TIMESTAMP)) AS VARCHAR)' .
                     ' ELSE %s END',
+                    $colRef,
+                    $colRef,
+                    $colRef,
+                    $colRef,
                     $colRef,
                     $colRef,
                     $colRef,
@@ -144,7 +152,8 @@ class TimestampConverter
         }
 
         return sprintf(
-            'COPY (SELECT %s FROM read_csv(\'%s\', header=false, columns={%s},'
+            'INSTALL icu; LOAD icu;'
+            . ' COPY (SELECT %s FROM read_csv(\'%s\', header=false, columns={%s},'
             . ' auto_detect=false, compression=\'gzip\', quote=\'"\', escape=\'"\','
             . ' null_padding=true, ignore_errors=true))'
             . ' TO \'%s\' (FORMAT CSV, HEADER false, COMPRESSION \'gzip\', QUOTE \'"\');',

--- a/tests/phpunit/TimestampConverterTest.php
+++ b/tests/phpunit/TimestampConverterTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AppProjectMigrateLargeTables\Tests;
+
+use Keboola\AppProjectMigrateLargeTables\TimestampConverter;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class TimestampConverterTest extends TestCase
+{
+    /**
+     * @dataProvider provideTimestampConversionData
+     * @param array<int, array<string, string>> $rows Each row is [col_index => value]
+     * @param array<int, array<string, string>> $expectedRows
+     */
+    public function testTimestampConversion(
+        string $sourceTimezone,
+        array $rows,
+        array $expectedRows,
+        bool $hasInternalTimestamp = false,
+    ): void {
+        $columns = ['ts_col', 'other_col'];
+        $columnMetadata = [
+            'ts_col' => [
+                ['provider' => 'storage', 'key' => 'KBC.datatype.type', 'value' => 'TIMESTAMP_TZ'],
+            ],
+        ];
+
+        $converter = new TimestampConverter(
+            $columns,
+            $columnMetadata,
+            $sourceTimezone,
+            new NullLogger(),
+            $hasInternalTimestamp,
+        );
+
+        self::assertTrue($converter->hasTimestampColumns());
+
+        $tmpDir = sys_get_temp_dir() . '/ts_converter_test_' . uniqid();
+        mkdir($tmpDir, 0777, true);
+        $inputFile = $tmpDir . '/input.csv.gz';
+
+        $csvLines = [];
+        foreach ($rows as $row) {
+            $csvLines[] = $this->toCsvLine($row);
+        }
+        file_put_contents(
+            $inputFile,
+            gzencode(implode("\n", $csvLines) . "\n"),
+        );
+
+        $converter->processGzippedFile($inputFile);
+
+        $output = gzdecode((string) file_get_contents($inputFile));
+        self::assertNotFalse($output);
+        $outputLines = array_filter(explode("\n", $output), fn($l) => $l !== '');
+
+        self::assertCount(count($expectedRows), $outputLines, 'Row count mismatch');
+
+        foreach ($expectedRows as $i => $expectedRow) {
+            $actualRow = str_getcsv($outputLines[$i]);
+            foreach ($expectedRow as $colIdx => $expectedValue) {
+                self::assertSame(
+                    $expectedValue,
+                    $actualRow[$colIdx] ?? null,
+                    sprintf('Row %d, col %d mismatch', $i, $colIdx),
+                );
+            }
+        }
+
+        $this->removeDir($tmpDir);
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function provideTimestampConversionData(): array
+    {
+        return [
+            'TIMESTAMP_TZ with embedded offset -0800 should convert to UTC' => [
+                'sourceTimezone' => 'America/Los_Angeles',
+                'rows' => [
+                    ['2024-11-14 23:43:22.000 -0800', 'value1'],
+                ],
+                'expectedRows' => [
+                    [0 => '2024-11-15 07:43:22', 1 => 'value1'],
+                ],
+            ],
+            'TIMESTAMP_TZ with positive offset +0530 should convert to UTC' => [
+                'sourceTimezone' => 'Asia/Kolkata',
+                'rows' => [
+                    ['2024-11-14 23:43:22.000 +0530', 'value2'],
+                ],
+                'expectedRows' => [
+                    [0 => '2024-11-14 18:13:22', 1 => 'value2'],
+                ],
+            ],
+            'TIMESTAMP_TZ with UTC offset +0000' => [
+                'sourceTimezone' => 'America/Los_Angeles',
+                'rows' => [
+                    ['2024-11-14 23:43:22.000 +0000', 'value3'],
+                ],
+                'expectedRows' => [
+                    [0 => '2024-11-14 23:43:22', 1 => 'value3'],
+                ],
+            ],
+            'plain timestamp without offset uses sourceTimezone' => [
+                'sourceTimezone' => 'America/Los_Angeles',
+                'rows' => [
+                    ['2024-11-14 23:43:22.000', 'value4'],
+                ],
+                'expectedRows' => [
+                    [0 => '2024-11-15 07:43:22', 1 => 'value4'],
+                ],
+            ],
+            'empty and null values pass through unchanged' => [
+                'sourceTimezone' => 'America/Los_Angeles',
+                'rows' => [
+                    ['', 'value5'],
+                ],
+                'expectedRows' => [
+                    [0 => '', 1 => 'value5'],
+                ],
+            ],
+            'ISO format offset with colon, no space' => [
+                'sourceTimezone' => 'America/Los_Angeles',
+                'rows' => [
+                    ['2024-11-14 23:43:22.000000-08:00', 'value6'],
+                ],
+                'expectedRows' => [
+                    [0 => '2024-11-15 07:43:22', 1 => 'value6'],
+                ],
+            ],
+            'offset with space and colon' => [
+                'sourceTimezone' => 'America/Los_Angeles',
+                'rows' => [
+                    ['2024-11-14 23:43:22.000 -08:00', 'value7'],
+                ],
+                'expectedRows' => [
+                    [0 => '2024-11-15 07:43:22', 1 => 'value7'],
+                ],
+            ],
+            'offset without space and without colon' => [
+                'sourceTimezone' => 'America/Los_Angeles',
+                'rows' => [
+                    ['2024-11-14 23:43:22.000-0800', 'value8'],
+                ],
+                'expectedRows' => [
+                    [0 => '2024-11-15 07:43:22', 1 => 'value8'],
+                ],
+            ],
+            'multiple rows with mixed formats' => [
+                'sourceTimezone' => 'America/Los_Angeles',
+                'rows' => [
+                    ['2024-11-14 23:43:22.000 -0800', 'row1'],
+                    ['2024-06-15 10:00:00.000 -0700', 'row2'],
+                    ['2024-01-01 00:00:00.000', 'row3'],
+                    ['2024-11-14 23:43:22.000000-08:00', 'row4'],
+                ],
+                'expectedRows' => [
+                    [0 => '2024-11-15 07:43:22', 1 => 'row1'],
+                    [0 => '2024-06-15 17:00:00', 1 => 'row2'],
+                    [0 => '2024-01-01 08:00:00', 1 => 'row3'],
+                    [0 => '2024-11-15 07:43:22', 1 => 'row4'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param string[] $values
+     */
+    private function toCsvLine(array $values): string
+    {
+        $escaped = array_map(function (string $v): string {
+            if ($v === '') {
+                return '""';
+            }
+            return '"' . str_replace('"', '""', $v) . '"';
+        }, $values);
+        return implode(',', $escaped);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            if (is_dir($path)) {
+                $this->removeDir($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}


### PR DESCRIPTION
# feat: replace PHP timestamp conversion with DuckDB SQL

## Summary

Replaces the PHP row-by-row CSV timestamp conversion (`DateTime::createFromFormat` / `fgetcsv` loop) with DuckDB CLI execution for converting `TIMESTAMP_LTZ`/`TIMESTAMP_TZ` columns from a source timezone to UTC during SAPI migration.

**Note:** This PR is based on tag `163-parallel-conversion-types-timezones` (not `master`), so the diff includes prior unreleased changes: parallel SAPI migration, cross-backend type mapping, and the original PHP timestamp conversion. **The only new commits are the DuckDB replacement** (`Dockerfile` + `TimestampConverter.php` rewrite) and subsequent offset-parsing fixes.

**How it works:** `TimestampConverter::processGzippedFile()` now builds a DuckDB SQL query that reads gzipped CSV, applies `timezone('UTC', ...)` on detected timestamp columns, and writes back to gzipped CSV — all in a single `COPY ... TO` statement via `proc_open`.

## Updates since last revision

**Fixed production failure: regex false positive producing invalid offset `-23:97`** — The previous broadened regex (`[+-]\d{2}:?\d{2}$`) matched non-offset suffixes in real data, causing DuckDB to attempt casting the invalid timezone `-23:97`. This was observed in [job 60959534](https://connection.europe-west3.gcp.keboola.com/admin/projects/2563/queue/60959534).

**Replaced single broad regex with a 4-branch CASE expression** — Each branch uses a strict, context-aware regex that requires specific characters before the `[+-]` to prevent false positives:

| Branch | Regex | Matches | Conversion |
|--------|-------|---------|------------|
| 1 | `' [+-]\d{2}:?\d{2}$'` | Snowflake default: `22.000 -0800`, `22.000 -08:00` | `regexp_replace` to normalize → `TIMESTAMPTZ` |
| 2 | `'\d[+-]\d{2}:\d{2}$'` | ISO format: `22.000000-08:00` | Direct `::TIMESTAMPTZ` cast |
| 3 | `'\d[+-]\d{4}$'` | No-space no-colon: `22.000-0800` | `regexp_replace` to add colon → `TIMESTAMPTZ` |
| 4 | `TRY_CAST(col AS TIMESTAMP)` | Plain: `22.000` (no offset) | `timezone(sourceTimezone, ...)` fallback |

The key safety improvement: branches 1–3 all require a specific preceding character (space or digit) before `[+-]`, preventing matches against arbitrary string suffixes.

**Previous fixes (still included):**
- Fixed timezone offset parsing for all formats (space/no-space, colon/no-colon)
- Added PHPUnit tests (`TimestampConverterTest.php`) — 9 data-driven test cases, 51 assertions
- Fixed DuckDB "Permission denied" on read-only root filesystem (`ensureDuckDbHome()`)

## Review & Testing Checklist for Human

- [ ] **End-to-end test with job 60959534 data**: Re-run the migration for `src_ocm_orders` table (project 2563, europe-west3) and verify the `created_at` column values are correctly converted to UTC. The PHPUnit tests verify DuckDB SQL behavior in isolation but do **not** test the full migration pipeline.
- [ ] **Verify no new regex false positives**: The 4-branch approach is safer but branch 3 (`\d[+-]\d{4}$`) could still theoretically match non-offset data ending with `digit + [+-] + 4 digits`. Review sample data from production to confirm no false positives.
- [ ] **DuckDB timestamp output format**: Verify that `CAST(timezone('UTC', ...) AS VARCHAR)` produces a format Keboola Storage can parse on import. The old PHP code explicitly preserved `Y-m-d H:i:s[.u]` format; DuckDB's VARCHAR cast may differ (e.g., microsecond precision, `T` separator). PHPUnit tests show DuckDB outputs `YYYY-MM-DD HH:MM:SS` but this should be verified against actual Snowflake import.
- [ ] **`ignore_errors=true` in `read_csv`**: This silently drops unparseable CSV rows. The old PHP approach preserved all rows and only skipped conversion on unparseable timestamps. Confirm this is acceptable or consider removing `ignore_errors=true`.
- [ ] **SQL injection via `sourceTimezoneStr`**: The timezone string is interpolated directly into SQL without sanitization (`TimestampConverter.php` line ~165). While it comes from validated config, confirm there's no SQL injection risk via crafted timezone strings.

### Notes
- Tag to test: `163-parallel-conversion-types-timezones-duckdb-v3` (current head)
- DuckDB version: 1.1.3 (pinned via `ARG DUCKDB_VERSION`)
- PHPUnit tests: 9 test cases, 51 assertions (all passing)
- Link to Devin run: https://app.devin.ai/sessions/f93f270be2c84fab9509fd0e5fb3bd17
- Requested by: @yustme

## Release Notes
**Justification, description**

Replaces PHP-based timestamp timezone conversion with DuckDB SQL for improved performance on large CSV files during SAPI migration. Fixes permission denied error on read-only container filesystems and handles all timezone offset formats (Snowflake default, ISO, with/without space, with/without colon) using a 4-branch CASE expression to prevent regex false positives.

**Plans for Customer Communication**

N/A

**Impact Analysis**

Affects SAPI mode migrations with `TIMESTAMP_LTZ`/`TIMESTAMP_TZ` columns when `sourceTimezone` is configured.

**Deployment Plan**

N/A

**Rollback Plan**

Revert to tag `163-parallel-conversion-types-timezones` (PHP-based conversion)

**Post-Release Support Plan**

N/A