### PR TITLE
feat: native DuckDB TRY_STRPTIME for TIMESTAMP_LTZ/TZ to UTC conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,13 @@ EOF
 RUN pecl install xdebug \
     && docker-php-ext-enable xdebug
 
+# Install DuckDB CLI
+ARG DUCKDB_VERSION=1.1.3
+ADD https://github.com/duckdb/duckdb/releases/download/v${DUCKDB_VERSION}/duckdb_cli-linux-amd64.zip /tmp/duckdb.zip
+RUN unzip /tmp/duckdb.zip -d /usr/local/bin/ && rm /tmp/duckdb.zip && chmod +x /usr/local/bin/duckdb \
+    && duckdb -c "INSTALL icu;" \
+    && mkdir -p /.duckdb && cp -r /root/.duckdb/* /.duckdb/ && chmod -R 777 /.duckdb
+
 ## Composer - deps always cached unless changed
 # First copy only composer files
 COPY composer.* /code/

--- a/src/Component.php
+++ b/src/Component.php
@@ -37,6 +37,7 @@ class Component extends BaseComponent
                     $targetSapiClient,
                     $this->getLogger(),
                     $this->getConfig()->isDryRun(),
+                    $this->getConfig()->getSourceTimezone(),
                 );
                 break;
             case 'database':

--- a/src/Config.php
+++ b/src/Config.php
@@ -248,4 +248,9 @@ class Config extends BaseConfig
     {
         return (bool) $this->getValue(['parameters', 'migrateData'], true);
     }
+
+    public function getParallelism(): int
+    {
+        return $this->getIntValue(['parameters', 'parallelism'], 1);
+    }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -253,4 +253,11 @@ class Config extends BaseConfig
     {
         return $this->getIntValue(['parameters', 'parallelism'], 1);
     }
+
+    public function getSourceTimezone(): string
+    {
+        /** @var string $value */
+        $value = $this->getValue(['parameters', 'sourceTimezone'], 'America/Los_Angeles');
+        return $value;
+    }
 }

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -26,6 +26,7 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->scalarNode('#sourceKbcToken')->isRequired()->cannotBeEmpty()->end()
                 ->arrayNode('includeWorkspaceSchemas')->prototype('scalar')->end()->end()
                 ->booleanNode('preserveTimestamp')->defaultFalse()->end()
+                ->scalarNode('sourceTimezone')->defaultValue('America/Los_Angeles')->end()
                 ->arrayNode('tables')->prototype('scalar')->end()->end()
                 ->booleanNode('migrateData')->defaultTrue()->end()
                 ->arrayNode('replica')

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -19,6 +19,7 @@ class ConfigDefinition extends BaseConfigDefinition
             ->children()
                 ->enumNode('mode')->values(['sapi', 'database'])->defaultValue('sapi')->end()
                 ->booleanNode('dryRun')->defaultFalse()->end()
+                ->integerNode('parallelism')->defaultValue(1)->min(1)->max(10)->end()
                 ->booleanNode('isSourceByodb')->defaultFalse()->end()
                 ->scalarNode('sourceByodb')->end()
                 ->scalarNode('sourceKbcUrl')->isRequired()->cannotBeEmpty()->end()

--- a/src/StorageModifier.php
+++ b/src/StorageModifier.php
@@ -5,20 +5,26 @@ declare(strict_types=1);
 namespace Keboola\AppProjectMigrateLargeTables;
 
 use Keboola\Csv\CsvFile;
+use Keboola\Datatype\Definition\Bigquery;
+use Keboola\Datatype\Definition\Snowflake;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Exception as StorageApiException;
 use Keboola\StorageApi\Metadata;
 use Keboola\StorageApi\Options\Metadata\TableMetadataUpdateOptions;
 use Keboola\Temp\Temp;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 
 class StorageModifier
 {
     private Temp $tmp;
+    private LoggerInterface $logger;
 
-    public function __construct(readonly Client $client)
+    public function __construct(readonly Client $client, ?LoggerInterface $logger = null)
     {
         $this->tmp = new Temp();
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function createBucket(string $schemaName): void
@@ -59,6 +65,8 @@ class StorageModifier
 
     private function createTypedTable(array $tableInfo): void
     {
+        $sourceBackendType = $tableInfo['bucket']['backend'];
+        $destinationBackendType = $this->getDestinationBucketBackend($tableInfo['bucket']['id']);
         $columns = [];
         foreach ($tableInfo['columns'] as $column) {
             $columns[$column] = [];
@@ -72,18 +80,38 @@ class StorageModifier
                 }
                 $columnMetadata[$metadata['key']] = $metadata['value'];
             }
-
-            $definition = [
-                'type' => $columnMetadata['KBC.datatype.type'],
-                'nullable' => $columnMetadata['KBC.datatype.nullable'] === '1',
-            ];
-            if (isset($columnMetadata['KBC.datatype.length'])) {
-                $definition['length'] = $columnMetadata['KBC.datatype.length'];
+            if ($destinationBackendType !== $sourceBackendType) {
+                $sourceBaseType = $this->getBaseType(
+                    $sourceBackendType,
+                    $columnMetadata['KBC.datatype.type'],
+                );
+                switch ($destinationBackendType) {
+                    case 'snowflake':
+                        $definition = (Snowflake::getDefinitionForBasetype((string) $sourceBaseType))->toArray();
+                        break;
+                    case 'bigquery':
+                        $definition = (Bigquery::getDefinitionForBasetype((string) $sourceBaseType))->toArray();
+                        break;
+                    default:
+                        $this->logger->warning(sprintf(
+                            'Unsupported destination backend type "%s" for cross-backend type conversion',
+                            $destinationBackendType,
+                        ));
+                        continue 2;
+                }
+                $definition['nullable'] = $columnMetadata['KBC.datatype.nullable'] === '1';
+            } else {
+                $definition = [
+                    'type' => $columnMetadata['KBC.datatype.type'],
+                    'nullable' => $columnMetadata['KBC.datatype.nullable'] === '1',
+                ];
+                if (isset($columnMetadata['KBC.datatype.length'])) {
+                    $definition['length'] = $columnMetadata['KBC.datatype.length'];
+                }
+                if (isset($columnMetadata['KBC.datatype.default'])) {
+                    $definition['default'] = $columnMetadata['KBC.datatype.default'];
+                }
             }
-            if (isset($columnMetadata['KBC.datatype.default'])) {
-                $definition['default'] = $columnMetadata['KBC.datatype.default'];
-            }
-
             $columns[$columnName] = [
                 'name' => $columnName,
                 'definition' => $definition,
@@ -167,5 +195,23 @@ class StorageModifier
             ];
         }
         return $result;
+    }
+
+    private function getDestinationBucketBackend(string $bucketId): string
+    {
+        $bucket = $this->client->getBucket($bucketId);
+        return $bucket['backend'];
+    }
+
+    private function getBaseType(string $backend, string $originalType): ?string
+    {
+        switch ($backend) {
+            case 'snowflake':
+                return (new Snowflake($originalType))->getBasetype();
+            case 'bigquery':
+                return (new Bigquery($originalType))->getBasetype();
+            default:
+                return null;
+        }
     }
 }

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -8,6 +8,7 @@ use Keboola\AppProjectMigrateLargeTables\Config;
 use Keboola\AppProjectMigrateLargeTables\MigrateInterface;
 use Keboola\AppProjectMigrateLargeTables\StorageModifier;
 use Keboola\AppProjectMigrateLargeTables\Strategy\SapiMigrate\MigrateGcsLargeTable;
+use Keboola\AppProjectMigrateLargeTables\TimestampConverter;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Options\FileUploadOptions;
@@ -28,6 +29,7 @@ class SapiMigrate implements MigrateInterface
         private readonly Client $targetClient,
         private readonly LoggerInterface $logger,
         private readonly bool $dryRun = false,
+        private readonly string $sourceTimezone = 'America/Los_Angeles',
     ) {
         $this->storageModifier = new StorageModifier($this->targetClient);
         $this->migrateGcsLargeTable = new MigrateGcsLargeTable(
@@ -35,6 +37,7 @@ class SapiMigrate implements MigrateInterface
             $this->targetClient,
             $this->logger,
             $this->dryRun,
+            $this->sourceTimezone,
         );
     }
 
@@ -239,6 +242,7 @@ class SapiMigrate implements MigrateInterface
             if ($this->dryRun === false) {
                 $this->logger->info(sprintf('Downloading table %s', $tableIdStr));
                 $slices = $this->sourceClient->downloadSlicedFile($sourceFileId, $tmp->getTmpFolder());
+                $this->convertTimestampsInSlices($tableInfo, $slices);
                 $this->logger->info(sprintf('Uploading table %s', $tableIdStr));
                 $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);
             } else {
@@ -251,6 +255,7 @@ class SapiMigrate implements MigrateInterface
             if ($this->dryRun === false) {
                 $this->logger->info(sprintf('Downloading table %s', $tableIdStr));
                 $this->sourceClient->downloadFile($sourceFileId, $fileName);
+                $this->convertTimestampsInFile($tableInfo, $fileName);
                 $this->logger->info(sprintf('Uploading table %s', $tableIdStr));
                 $destinationFileId = $this->targetClient->uploadFile($fileName, $optionUploadedFile);
             } else {
@@ -299,6 +304,7 @@ class SapiMigrate implements MigrateInterface
             if ($this->dryRun === false) {
                 $this->logger->info(sprintf('Downloading table %s', $sourceTableInfo['id']));
                 $slices = $this->sourceClient->downloadSlicedFile($sourceFileId, $tmp->getTmpFolder());
+                $this->convertTimestampsInSlices($sourceTableInfo, $slices);
 
                 $this->logger->info(sprintf('Uploading table %s', $sourceTableInfo['id']));
                 $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);
@@ -312,6 +318,7 @@ class SapiMigrate implements MigrateInterface
             if ($this->dryRun === false) {
                 $this->logger->info(sprintf('Downloading table %s', $sourceTableInfo['id']));
                 $this->sourceClient->downloadFile($sourceFileId, $fileName);
+                $this->convertTimestampsInFile($sourceTableInfo, $fileName);
 
                 $this->logger->info(sprintf('Uploading table %s', $sourceTableInfo['id']));
                 $destinationFileId = $this->targetClient->uploadFile($fileName, $optionUploadedFile);
@@ -368,5 +375,49 @@ class SapiMigrate implements MigrateInterface
             );
         }
         return $listTables;
+    }
+
+    /**
+     * @param array<string, mixed> $tableInfo
+     */
+    private function createTimestampConverter(array $tableInfo): TimestampConverter
+    {
+        /** @var string[] $columns */
+        $columns = $tableInfo['columns'];
+        /** @var array<string, array<int, array<string, string>>> $columnMetadata */
+        $columnMetadata = $tableInfo['columnMetadata'] ?? [];
+        return new TimestampConverter(
+            $columns,
+            $columnMetadata,
+            $this->sourceTimezone,
+            $this->logger,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $tableInfo
+     * @param string[] $slicePaths
+     */
+    private function convertTimestampsInSlices(array $tableInfo, array $slicePaths): void
+    {
+        $converter = $this->createTimestampConverter($tableInfo);
+        if ($converter->hasTimestampColumns()) {
+            assert(is_string($tableInfo['id']));
+            $this->logger->info(sprintf('Converting timezone timestamps to UTC for table %s', $tableInfo['id']));
+            $converter->processGzippedSlices($slicePaths);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $tableInfo
+     */
+    private function convertTimestampsInFile(array $tableInfo, string $filePath): void
+    {
+        $converter = $this->createTimestampConverter($tableInfo);
+        if ($converter->hasTimestampColumns()) {
+            assert(is_string($tableInfo['id']));
+            $this->logger->info(sprintf('Converting timezone timestamps to UTC for table %s', $tableInfo['id']));
+            $converter->processGzippedFile($filePath);
+        }
     }
 }

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -40,6 +40,25 @@ class SapiMigrate implements MigrateInterface
 
     public function migrate(Config $config): void
     {
+        $parallelism = $config->getParallelism();
+        $tablesToMigrate = $this->prepareTablesToMigrate($config);
+        if ($parallelism <= 1) {
+            foreach ($tablesToMigrate as $tableInfo) {
+                $this->migrateTable($tableInfo, $config);
+            }
+        } else {
+            $this->logger->info(sprintf('Migrating tables with parallelism: %d', $parallelism));
+            $this->migrateTablesInParallel($tablesToMigrate, $config, $parallelism);
+        }
+    }
+
+    /**
+     * Prepares tables for migration by validating them and creating buckets/tables as needed.
+     * @return array<array<string, mixed>> Array of table info arrays ready for migration
+     */
+    private function prepareTablesToMigrate(Config $config): array
+    {
+        $tablesToMigrate = [];
         foreach ($config->getMigrateTables() ?: $this->getAllTables() as $tableId) {
             try {
                 $tableInfo = $this->sourceClient->getTable($tableId);
@@ -55,12 +74,10 @@ class SapiMigrate implements MigrateInterface
                 $this->logger->warning(sprintf('Skipping table %s (sys bucket)', $tableInfo['id']));
                 continue;
             }
-
             if ($tableInfo['isAlias']) {
                 $this->logger->warning(sprintf('Skipping table %s (alias)', $tableInfo['id']));
                 continue;
             }
-
             if (!in_array($tableInfo['bucket']['id'], $this->bucketsExist) &&
                 !$this->targetClient->bucketExists($tableInfo['bucket']['id'])) {
                 if ($this->dryRun) {
@@ -68,11 +85,9 @@ class SapiMigrate implements MigrateInterface
                 } else {
                     $this->logger->info(sprintf('Creating bucket %s', $tableInfo['bucket']['id']));
                     $this->bucketsExist[] = $tableInfo['bucket']['id'];
-
                     $this->storageModifier->createBucket($tableInfo['bucket']['id']);
                 }
             }
-
             if (!$this->targetClient->tableExists($tableId)) {
                 if ($this->dryRun) {
                     $this->logger->info(sprintf('[dry-run] Creating table %s', $tableInfo['id']));
@@ -81,9 +96,171 @@ class SapiMigrate implements MigrateInterface
                     $this->storageModifier->createTable($tableInfo);
                 }
             }
-
-            $this->migrateTable($tableInfo, $config);
+            $tablesToMigrate[] = $tableInfo;
         }
+        return $tablesToMigrate;
+    }
+
+    /**
+     * Migrates tables in parallel batches.
+     * @param array<array<string, mixed>> $tablesToMigrate
+     */
+    private function migrateTablesInParallel(array $tablesToMigrate, Config $config, int $parallelism): void
+    {
+        $batches = array_chunk($tablesToMigrate, max(1, $parallelism));
+        foreach ($batches as $batchIndex => $batch) {
+            $this->logger->info(sprintf(
+                'Processing batch %d/%d (%d tables)',
+                $batchIndex + 1,
+                count($batches),
+                count($batch),
+            ));
+            $this->processBatch($batch, $config);
+        }
+    }
+
+    /**
+     * Processes a batch of tables in parallel.
+     * @param array<array<string, mixed>> $batch
+     */
+    private function processBatch(array $batch, Config $config): void
+    {
+        $exportJobs = [];
+        foreach ($batch as $tableInfo) {
+            assert(is_string($tableInfo['id']));
+            $tableId = $tableInfo['id'];
+            $this->logger->info(sprintf('Queueing export for table %s', $tableId));
+            $jobId = $this->sourceClient->queueTableExport($tableId, [
+                'gzip' => true,
+                'includeInternalTimestamp' => $config->preserveTimestamp(),
+            ]);
+            $exportJobs[$tableId] = [
+                'jobId' => $jobId,
+                'tableInfo' => $tableInfo,
+            ];
+        }
+        $exportResults = [];
+        foreach ($exportJobs as $tableId => $jobData) {
+            $this->logger->info(sprintf('Waiting for export job for table %s', $tableId));
+            $job = $this->sourceClient->waitForJob($jobData['jobId']);
+            if ($job === null || $job['status'] !== 'success') {
+                $errorMessage = $job['error']['message'] ?? 'Unknown error';
+                $this->logger->warning(sprintf(
+                    'Export failed for table %s: %s',
+                    $tableId,
+                    $errorMessage,
+                ));
+                continue;
+            }
+            $results = $job['results'];
+            assert(is_array($results) && is_array($results['file']));
+            $file = $results['file'];
+            assert(isset($file['id']) && is_int($file['id']));
+            $fileId = $file['id'];
+            $exportResults[$tableId] = [
+                'tableInfo' => $jobData['tableInfo'],
+                'fileId' => $fileId,
+            ];
+        }
+        $uploadResults = [];
+        foreach ($exportResults as $tableId => $exportData) {
+            $result = $this->downloadAndUpload($exportData['tableInfo'], $exportData['fileId'], $config);
+            if ($result !== null) {
+                $uploadResults[$tableId] = [
+                    'tableInfo' => $exportData['tableInfo'],
+                    'destinationFileId' => $result,
+                ];
+            }
+        }
+        $importJobs = [];
+        foreach ($uploadResults as $tableId => $uploadData) {
+            if ($this->dryRun) {
+                assert(is_string($uploadData['tableInfo']['name']));
+                $tableName = $uploadData['tableInfo']['name'];
+                $this->logger->info(sprintf('[dry-run] Import data to table "%s"', $tableName));
+                continue;
+            }
+            $this->logger->info(sprintf('Queueing import for table %s', $tableId));
+            $jobId = $this->targetClient->queueTableImport(
+                $tableId,
+                [
+                    'name' => $uploadData['tableInfo']['name'],
+                    'dataFileId' => $uploadData['destinationFileId'],
+                    'columns' => $uploadData['tableInfo']['columns'],
+                    'useTimestampFromDataFile' => $config->preserveTimestamp(),
+                ],
+            );
+            $importJobs[$tableId] = $jobId;
+        }
+        foreach ($importJobs as $tableId => $jobId) {
+            $this->logger->info(sprintf('Waiting for import job for table %s', $tableId));
+            $job = $this->targetClient->waitForJob($jobId);
+            if ($job === null || $job['status'] !== 'success') {
+                $errorMessage = $job['error']['message'] ?? 'Unknown error';
+                $this->logger->warning(sprintf(
+                    'Import failed for table %s: %s',
+                    $tableId,
+                    $errorMessage,
+                ));
+            }
+        }
+    }
+
+    /**
+     * Downloads file from source and uploads to target.
+     * @param array<string, mixed> $tableInfo
+     * @return int|null The destination file ID, or null if dry run or large GCS table
+     */
+    private function downloadAndUpload(array $tableInfo, int $sourceFileId, Config $config): ?int
+    {
+        $sourceFileInfo = $this->sourceClient->getFile($sourceFileId);
+        $tmp = new Temp();
+        $optionUploadedFile = new FileUploadOptions();
+        assert(is_string($tableInfo['id']));
+        $tableIdStr = $tableInfo['id'];
+        $optionUploadedFile
+            ->setFederationToken(true)
+            ->setFileName($tableIdStr);
+        $tableSize = $sourceFileInfo['sizeBytes'];
+        if ($sourceFileInfo['provider'] === 'gcp' &&
+            $sourceFileInfo['isSliced'] === true &&
+            $tableSize > self::LARGE_GCS_TABLE_SIZE
+        ) {
+            $this->migrateGcsLargeTable->migrate(
+                $sourceFileId,
+                $tableInfo,
+                $config->preserveTimestamp(),
+                $tmp,
+            );
+            $tmp->remove();
+            return null;
+        } elseif ($sourceFileInfo['isSliced'] === true) {
+            $optionUploadedFile->setIsSliced(true);
+            if ($this->dryRun === false) {
+                $this->logger->info(sprintf('Downloading table %s', $tableIdStr));
+                $slices = $this->sourceClient->downloadSlicedFile($sourceFileId, $tmp->getTmpFolder());
+                $this->logger->info(sprintf('Uploading table %s', $tableIdStr));
+                $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);
+            } else {
+                $this->logger->info(sprintf('[dry-run] Migrate table %s', $tableIdStr));
+                $tmp->remove();
+                return null;
+            }
+        } else {
+            $fileName = $tmp->getTmpFolder() . '/' . $sourceFileInfo['name'];
+            if ($this->dryRun === false) {
+                $this->logger->info(sprintf('Downloading table %s', $tableIdStr));
+                $this->sourceClient->downloadFile($sourceFileId, $fileName);
+                $this->logger->info(sprintf('Uploading table %s', $tableIdStr));
+                $destinationFileId = $this->targetClient->uploadFile($fileName, $optionUploadedFile);
+            } else {
+                $this->logger->info(sprintf('[dry-run] Uploading table %s', $tableIdStr));
+                $tmp->remove();
+                return null;
+            }
+        }
+        $tmp->remove();
+        return $destinationFileId;
     }
 
     private function migrateTable(array $sourceTableInfo, Config $config): void

--- a/src/Strategy/SapiMigrate/MigrateGcsLargeTable.php
+++ b/src/Strategy/SapiMigrate/MigrateGcsLargeTable.php
@@ -7,6 +7,7 @@ namespace Keboola\AppProjectMigrateLargeTables\Strategy\SapiMigrate;
 use Google\Auth\FetchAuthTokenInterface;
 use Google\Cloud\Storage\StorageClient as GoogleStorageClient;
 use GuzzleHttp\Utils;
+use Keboola\AppProjectMigrateLargeTables\TimestampConverter;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\Options\FileUploadOptions;
 use Keboola\StorageApi\Options\GetFileOptions;
@@ -23,6 +24,7 @@ class MigrateGcsLargeTable
         private readonly Client $targetClient,
         private readonly LoggerInterface $logger,
         private readonly bool $dryRun = false,
+        private readonly string $sourceTimezone = 'America/Los_Angeles',
     ) {
     }
 
@@ -74,6 +76,22 @@ class MigrateGcsLargeTable
                 );
                 $blobPath = explode($sprintf, $entry['url']);
                 $retBucket->object($blobPath[1])->downloadToFile($destinationFile);
+            }
+
+            $converter = new TimestampConverter(
+                $tableInfo['columns'],
+                $tableInfo['columnMetadata'] ?? [],
+                $this->sourceTimezone,
+                $this->logger,
+            );
+            if ($converter->hasTimestampColumns()) {
+                $this->logger->info(sprintf(
+                    'Converting timezone timestamps to UTC for table %s (chunk %d/%d)',
+                    $tableInfo['id'],
+                    $chunkKey + 1,
+                    count($chunks),
+                ));
+                $converter->processGzippedSlices($slices);
             }
 
             $destinationFileId = $this->targetClient->uploadSlicedFile($slices, $optionUploadedFile);

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -120,7 +120,8 @@ class TimestampConverter
 
     private function buildDuckDbQuery(string $inputPath, string $outputPath): string
     {
-        $columnCount = count($this->columns);
+        $actualColumnCount = $this->detectCsvColumnCount($inputPath);
+        $columnCount = max($actualColumnCount, count($this->columns));
 
         $columnDefs = [];
         for ($i = 0; $i < $columnCount; $i++) {
@@ -167,6 +168,18 @@ class TimestampConverter
             implode(', ', $columnDefs),
             addcslashes($outputPath, "'"),
         );
+    }
+
+    private function detectCsvColumnCount(string $gzippedFilePath): int
+    {
+        $fh = gzopen($gzippedFilePath, 'rb');
+        if ($fh === false) {
+            throw new RuntimeException(sprintf('Cannot open gzipped file: %s', $gzippedFilePath));
+        }
+        $firstLine = (string) gzgets($fh);
+        gzclose($fh);
+        $row = str_getcsv($firstLine, ',', '"', '');
+        return count($row);
     }
 
     private function ensureDuckDbHome(): string

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -133,12 +133,12 @@ class TimestampConverter
             if (in_array($i, $this->timestampColumnIndices, true)) {
                 $selectExprs[] = sprintf(
                     'CASE WHEN %s IS NOT NULL AND %s != \'\''
-                    . ' THEN CAST(timezone(\'UTC\', COALESCE('
+                    . ' THEN COALESCE(CAST(timezone(\'UTC\', COALESCE('
                     . ' TRY_STRPTIME(%s, \'%%Y-%%m-%%d %%H:%%M:%%S.%%f %%z\'),'
                     . ' TRY_STRPTIME(%s, \'%%Y-%%m-%%d %%H:%%M:%%S %%z\'),'
                     . ' timezone(\'%s\', TRY_STRPTIME(%s, \'%%Y-%%m-%%d %%H:%%M:%%S.%%f\')),'
                     . ' timezone(\'%s\', TRY_STRPTIME(%s, \'%%Y-%%m-%%d %%H:%%M:%%S\'))'
-                    . ')) AS VARCHAR)'
+                    . ')) AS VARCHAR), %s)'
                     . ' ELSE %s END',
                     $colRef,
                     $colRef,
@@ -147,6 +147,7 @@ class TimestampConverter
                     $this->sourceTimezoneStr,
                     $colRef,
                     $this->sourceTimezoneStr,
+                    $colRef,
                     $colRef,
                     $colRef,
                 );

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AppProjectMigrateLargeTables;
+
+use DateTime;
+use DateTimeZone;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+class TimestampConverter
+{
+    private const TIMESTAMP_TYPES_WITH_TIMEZONE = [
+        'TIMESTAMP_LTZ',
+        'TIMESTAMP_TZ',
+    ];
+
+    /** @var int[] */
+    private array $timestampColumnIndices;
+    private DateTimeZone $sourceTimezone;
+    private DateTimeZone $utcTimezone;
+
+    /**
+     * @param string[] $columns
+     * @param array<string, array<int, array<string, string>>> $columnMetadata
+     */
+    public function __construct(
+        array $columns,
+        array $columnMetadata,
+        string $sourceTimezone,
+        private readonly LoggerInterface $logger,
+    ) {
+        $this->sourceTimezone = new DateTimeZone($sourceTimezone);
+        $this->utcTimezone = new DateTimeZone('UTC');
+        $this->timestampColumnIndices = $this->detectTimestampColumns($columns, $columnMetadata);
+    }
+
+    public function hasTimestampColumns(): bool
+    {
+        return !empty($this->timestampColumnIndices);
+    }
+
+    public function processGzippedFile(string $filePath): void
+    {
+        if (!$this->hasTimestampColumns()) {
+            return;
+        }
+
+        $tempPath = $filePath . '.converting';
+
+        $input = fopen('compress.zlib://' . $filePath, 'r');
+        if ($input === false) {
+            throw new RuntimeException(sprintf('Cannot open file for reading: %s', $filePath));
+        }
+
+        $output = gzopen($tempPath, 'wb');
+        if ($output === false) {
+            fclose($input);
+            throw new RuntimeException(sprintf('Cannot open file for writing: %s', $tempPath));
+        }
+
+        $rowCount = 0;
+        while (($row = fgetcsv($input, 0, ',', '"', '\\')) !== false) {
+            foreach ($this->timestampColumnIndices as $idx) {
+                if (isset($row[$idx]) && $row[$idx] !== '') {
+                    $row[$idx] = $this->convertTimestamp($row[$idx]);
+                }
+            }
+            gzwrite($output, $this->toCsvLine($row));
+            $rowCount++;
+        }
+
+        fclose($input);
+        gzclose($output);
+
+        unlink($filePath);
+        rename($tempPath, $filePath);
+
+        $this->logger->info(sprintf('Converted timestamps to UTC in %d rows', $rowCount));
+    }
+
+    /**
+     * @param string[] $slicePaths
+     */
+    public function processGzippedSlices(array $slicePaths): void
+    {
+        if (!$this->hasTimestampColumns()) {
+            return;
+        }
+
+        foreach ($slicePaths as $path) {
+            $this->processGzippedFile($path);
+        }
+    }
+
+    /**
+     * @param string[] $columns
+     * @param array<string, array<int, array<string, string>>> $columnMetadata
+     * @return int[]
+     */
+    private function detectTimestampColumns(array $columns, array $columnMetadata): array
+    {
+        $indices = [];
+        foreach ($columns as $index => $columnName) {
+            $metadata = $columnMetadata[$columnName] ?? [];
+            foreach ($metadata as $m) {
+                if (($m['provider'] ?? '') === 'storage' && ($m['key'] ?? '') === 'KBC.datatype.type') {
+                    if (in_array(strtoupper($m['value'] ?? ''), self::TIMESTAMP_TYPES_WITH_TIMEZONE, true)) {
+                        $this->logger->info(sprintf(
+                            'Column "%s" (index %d) is %s — will convert to UTC',
+                            $columnName,
+                            $index,
+                            $m['value'],
+                        ));
+                        $indices[] = $index;
+                    }
+                    break;
+                }
+            }
+        }
+        return $indices;
+    }
+
+    private function convertTimestamp(string $value): string
+    {
+        $dt = DateTime::createFromFormat('Y-m-d H:i:s.u', $value, $this->sourceTimezone);
+        if ($dt !== false) {
+            $dt->setTimezone($this->utcTimezone);
+            return $dt->format('Y-m-d H:i:s.u');
+        }
+
+        $dt = DateTime::createFromFormat('Y-m-d H:i:s', $value, $this->sourceTimezone);
+        if ($dt !== false) {
+            $dt->setTimezone($this->utcTimezone);
+            return $dt->format('Y-m-d H:i:s');
+        }
+
+        $this->logger->warning(sprintf('Cannot parse timestamp value: %s', $value));
+        return $value;
+    }
+
+    /**
+     * @param array<int, string|null> $fields
+     */
+    private function toCsvLine(array $fields): string
+    {
+        $parts = [];
+        foreach ($fields as $field) {
+            if ($field === null) {
+                $parts[] = '';
+            } elseif ($this->needsQuoting($field)) {
+                $parts[] = '"' . str_replace('"', '""', $field) . '"';
+            } else {
+                $parts[] = $field;
+            }
+        }
+        return implode(',', $parts) . "\n";
+    }
+
+    private function needsQuoting(string $field): bool
+    {
+        return str_contains($field, ',')
+            || str_contains($field, '"')
+            || str_contains($field, "\n")
+            || str_contains($field, "\r");
+    }
+}

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Keboola\AppProjectMigrateLargeTables;
 
-use DateTime;
-use DateTimeZone;
 use Psr\Log\LoggerInterface;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
 use RuntimeException;
+use SplFileInfo;
 
 class TimestampConverter
 {
@@ -16,10 +17,14 @@ class TimestampConverter
         'TIMESTAMP_TZ',
     ];
 
+    private const DUCKDB_BINARY = 'duckdb';
+    private const DUCKDB_EXTENSIONS_SOURCE = '/.duckdb';
+
     /** @var int[] */
     private array $timestampColumnIndices;
-    private DateTimeZone $sourceTimezone;
-    private DateTimeZone $utcTimezone;
+    /** @var string[] */
+    private array $columns;
+    private string $sourceTimezoneStr;
 
     /**
      * @param string[] $columns
@@ -31,9 +36,9 @@ class TimestampConverter
         string $sourceTimezone,
         private readonly LoggerInterface $logger,
     ) {
-        $this->sourceTimezone = new DateTimeZone($sourceTimezone);
-        $this->utcTimezone = new DateTimeZone('UTC');
-        $this->timestampColumnIndices = $this->detectTimestampColumns($columns, $columnMetadata);
+        $this->columns = array_values($columns);
+        $this->sourceTimezoneStr = $sourceTimezone;
+        $this->timestampColumnIndices = $this->detectTimestampColumns($this->columns, $columnMetadata);
     }
 
     public function hasTimestampColumns(): bool
@@ -48,36 +53,55 @@ class TimestampConverter
         }
 
         $tempPath = $filePath . '.converting';
+        $sql = $this->buildDuckDbQuery($filePath, $tempPath);
 
-        $input = fopen('compress.zlib://' . $filePath, 'r');
-        if ($input === false) {
-            throw new RuntimeException(sprintf('Cannot open file for reading: %s', $filePath));
+        $this->logger->info(sprintf('Running DuckDB timestamp conversion on %s', basename($filePath)));
+
+        $duckDbHome = $this->ensureDuckDbHome();
+
+        $descriptorspec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $env = getenv();
+        $env['HOME'] = $duckDbHome;
+
+        $process = proc_open(
+            [self::DUCKDB_BINARY, '-c', $sql],
+            $descriptorspec,
+            $pipes,
+            null,
+            $env,
+        );
+
+        if (!is_resource($process)) {
+            throw new RuntimeException('Failed to start DuckDB process');
         }
 
-        $output = gzopen($tempPath, 'wb');
-        if ($output === false) {
-            fclose($input);
-            throw new RuntimeException(sprintf('Cannot open file for writing: %s', $tempPath));
+        fclose($pipes[0]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        if ($exitCode !== 0) {
+            throw new RuntimeException(sprintf(
+                'DuckDB timestamp conversion failed (exit code %d): %s',
+                $exitCode,
+                $stderr,
+            ));
         }
 
-        $rowCount = 0;
-        while (($row = fgetcsv($input, 0, ',', '"', '\\')) !== false) {
-            foreach ($this->timestampColumnIndices as $idx) {
-                if (isset($row[$idx]) && $row[$idx] !== '') {
-                    $row[$idx] = $this->convertTimestamp($row[$idx]);
-                }
-            }
-            gzwrite($output, $this->toCsvLine($row));
-            $rowCount++;
+        if (!file_exists($tempPath)) {
+            throw new RuntimeException(sprintf('DuckDB output file not found: %s', $tempPath));
         }
-
-        fclose($input);
-        gzclose($output);
 
         unlink($filePath);
         rename($tempPath, $filePath);
 
-        $this->logger->info(sprintf('Converted timestamps to UTC in %d rows', $rowCount));
+        $this->logger->info('DuckDB timestamp conversion completed');
     }
 
     /**
@@ -91,6 +115,86 @@ class TimestampConverter
 
         foreach ($slicePaths as $path) {
             $this->processGzippedFile($path);
+        }
+    }
+
+    private function buildDuckDbQuery(string $inputPath, string $outputPath): string
+    {
+        $columnCount = count($this->columns);
+
+        $columnDefs = [];
+        for ($i = 0; $i < $columnCount; $i++) {
+            $columnDefs[] = sprintf("'col_%d': 'VARCHAR'", $i);
+        }
+
+        $selectExprs = [];
+        for ($i = 0; $i < $columnCount; $i++) {
+            $colRef = sprintf('"col_%d"', $i);
+            if (in_array($i, $this->timestampColumnIndices, true)) {
+                $selectExprs[] = sprintf(
+                    'CASE WHEN %s IS NOT NULL AND %s != \'\''
+                    . ' THEN CAST(timezone(\'UTC\', COALESCE('
+                    . ' TRY_STRPTIME(%s, \'%%Y-%%m-%%d %%H:%%M:%%S.%%g %%z\'),'
+                    . ' TRY_STRPTIME(%s, \'%%Y-%%m-%%d %%H:%%M:%%S %%z\'),'
+                    . ' timezone(\'%s\', TRY_CAST(%s AS TIMESTAMP))'
+                    . ')) AS VARCHAR)'
+                    . ' ELSE %s END',
+                    $colRef,
+                    $colRef,
+                    $colRef,
+                    $colRef,
+                    $this->sourceTimezoneStr,
+                    $colRef,
+                    $colRef,
+                );
+            } else {
+                $selectExprs[] = $colRef;
+            }
+        }
+
+        return sprintf(
+            'LOAD icu;'
+            . ' COPY (SELECT %s FROM read_csv(\'%s\', header=false, columns={%s},'
+            . ' auto_detect=false, compression=\'gzip\', quote=\'"\', escape=\'"\','
+            . ' null_padding=true, ignore_errors=true))'
+            . ' TO \'%s\' (FORMAT CSV, HEADER false, COMPRESSION \'gzip\', QUOTE \'"\');',
+            implode(', ', $selectExprs),
+            addcslashes($inputPath, "'"),
+            implode(', ', $columnDefs),
+            addcslashes($outputPath, "'"),
+        );
+    }
+
+    private function ensureDuckDbHome(): string
+    {
+        $home = sys_get_temp_dir() . '/duckdb-home';
+        $targetDir = $home . '/.duckdb';
+        if (!is_dir($targetDir) && is_dir(self::DUCKDB_EXTENSIONS_SOURCE)) {
+            $this->recursiveCopy(self::DUCKDB_EXTENSIONS_SOURCE, $targetDir);
+        }
+        if (!is_dir($home)) {
+            mkdir($home, 0777, true);
+        }
+        return $home;
+    }
+
+    private function recursiveCopy(string $source, string $destination): void
+    {
+        mkdir($destination, 0777, true);
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST,
+        );
+        foreach ($iterator as $item) {
+            assert($item instanceof SplFileInfo);
+            $target = $destination . '/' . $iterator->getSubPathname();
+            if ($item->isDir()) {
+                if (!is_dir($target)) {
+                    mkdir($target, 0777, true);
+                }
+            } else {
+                copy($item->getPathname(), $target);
+            }
         }
     }
 
@@ -108,7 +212,7 @@ class TimestampConverter
                 if (($m['provider'] ?? '') === 'storage' && ($m['key'] ?? '') === 'KBC.datatype.type') {
                     if (in_array(strtoupper($m['value'] ?? ''), self::TIMESTAMP_TYPES_WITH_TIMEZONE, true)) {
                         $this->logger->info(sprintf(
-                            'Column "%s" (index %d) is %s — will convert to UTC',
+                            'Column "%s" (index %d) is %s — will convert to UTC via DuckDB',
                             $columnName,
                             $index,
                             $m['value'],
@@ -120,49 +224,5 @@ class TimestampConverter
             }
         }
         return $indices;
-    }
-
-    private function convertTimestamp(string $value): string
-    {
-        $dt = DateTime::createFromFormat('Y-m-d H:i:s.u', $value, $this->sourceTimezone);
-        if ($dt !== false) {
-            $dt->setTimezone($this->utcTimezone);
-            return $dt->format('Y-m-d H:i:s.u');
-        }
-
-        $dt = DateTime::createFromFormat('Y-m-d H:i:s', $value, $this->sourceTimezone);
-        if ($dt !== false) {
-            $dt->setTimezone($this->utcTimezone);
-            return $dt->format('Y-m-d H:i:s');
-        }
-
-        $this->logger->warning(sprintf('Cannot parse timestamp value: %s', $value));
-        return $value;
-    }
-
-    /**
-     * @param array<int, string|null> $fields
-     */
-    private function toCsvLine(array $fields): string
-    {
-        $parts = [];
-        foreach ($fields as $field) {
-            if ($field === null) {
-                $parts[] = '';
-            } elseif ($this->needsQuoting($field)) {
-                $parts[] = '"' . str_replace('"', '""', $field) . '"';
-            } else {
-                $parts[] = $field;
-            }
-        }
-        return implode(',', $parts) . "\n";
-    }
-
-    private function needsQuoting(string $field): bool
-    {
-        return str_contains($field, ',')
-            || str_contains($field, '"')
-            || str_contains($field, "\n")
-            || str_contains($field, "\r");
     }
 }

--- a/src/TimestampConverter.php
+++ b/src/TimestampConverter.php
@@ -134,14 +134,17 @@ class TimestampConverter
                 $selectExprs[] = sprintf(
                     'CASE WHEN %s IS NOT NULL AND %s != \'\''
                     . ' THEN CAST(timezone(\'UTC\', COALESCE('
-                    . ' TRY_STRPTIME(%s, \'%%Y-%%m-%%d %%H:%%M:%%S.%%g %%z\'),'
+                    . ' TRY_STRPTIME(%s, \'%%Y-%%m-%%d %%H:%%M:%%S.%%f %%z\'),'
                     . ' TRY_STRPTIME(%s, \'%%Y-%%m-%%d %%H:%%M:%%S %%z\'),'
-                    . ' timezone(\'%s\', TRY_CAST(%s AS TIMESTAMP))'
+                    . ' timezone(\'%s\', TRY_STRPTIME(%s, \'%%Y-%%m-%%d %%H:%%M:%%S.%%f\')),'
+                    . ' timezone(\'%s\', TRY_STRPTIME(%s, \'%%Y-%%m-%%d %%H:%%M:%%S\'))'
                     . ')) AS VARCHAR)'
                     . ' ELSE %s END',
                     $colRef,
                     $colRef,
                     $colRef,
+                    $colRef,
+                    $this->sourceTimezoneStr,
                     $colRef,
                     $this->sourceTimezoneStr,
                     $colRef,
@@ -156,8 +159,8 @@ class TimestampConverter
             'LOAD icu;'
             . ' COPY (SELECT %s FROM read_csv(\'%s\', header=false, columns={%s},'
             . ' auto_detect=false, compression=\'gzip\', quote=\'"\', escape=\'"\','
-            . ' null_padding=true, ignore_errors=true))'
-            . ' TO \'%s\' (FORMAT CSV, HEADER false, COMPRESSION \'gzip\', QUOTE \'"\');',
+            . ' null_padding=true))'
+            . ' TO \'%s\' (FORMAT CSV, HEADER false, COMPRESSION \'gzip\', QUOTE \'"\', FORCE_QUOTE *);',
             implode(', ', $selectExprs),
             addcslashes($inputPath, "'"),
             implode(', ', $columnDefs),

--- a/tests/phpunit/TimestampConverterTest.php
+++ b/tests/phpunit/TimestampConverterTest.php
@@ -214,6 +214,23 @@ class TimestampConverterTest extends TestCase
         self::assertSame('text with, comma', $rows[0][2]);
     }
 
+    public function testExtraColumnsInCsvBeyondMetadata(): void
+    {
+        $filePath = $this->createGzippedCsv([
+            ['1', '2024-11-14 23:43:22.000 -0800', 'hello', 'extra_value'],
+        ]);
+
+        $converter = $this->createConverter(['id', 'ts', 'name'], 'ts', 'TIMESTAMP_LTZ');
+        $converter->processGzippedFile($filePath);
+
+        $rows = $this->readGzippedCsv($filePath);
+        self::assertCount(1, $rows);
+        self::assertCount(4, $rows[0]);
+        self::assertSame('2024-11-15 07:43:22', $rows[0][1]);
+        self::assertSame('hello', $rows[0][2]);
+        self::assertSame('extra_value', $rows[0][3]);
+    }
+
     public function testProcessGzippedSlices(): void
     {
         $file1 = $this->createGzippedCsv([

--- a/tests/phpunit/TimestampConverterTest.php
+++ b/tests/phpunit/TimestampConverterTest.php
@@ -137,6 +137,20 @@ class TimestampConverterTest extends TestCase
         self::assertSame('2024-11-14 23:43:22', $rows[0][1]);
     }
 
+    public function testSixDigitMicroseconds(): void
+    {
+        $filePath = $this->createGzippedCsv([
+            ['1', '2024-11-14 23:43:22.000000 -0800', 'hello'],
+        ]);
+
+        $converter = $this->createConverter(['id', 'ts', 'name'], 'ts', 'TIMESTAMP_LTZ');
+        $converter->processGzippedFile($filePath);
+
+        $rows = $this->readGzippedCsv($filePath);
+        self::assertCount(1, $rows);
+        self::assertSame('2024-11-15 07:43:22', $rows[0][1]);
+    }
+
     public function testNoFractionalSecondsWithOffset(): void
     {
         $filePath = $this->createGzippedCsv([

--- a/tests/phpunit/TimestampConverterTest.php
+++ b/tests/phpunit/TimestampConverterTest.php
@@ -1,0 +1,275 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AppProjectMigrateLargeTables\Tests;
+
+use Keboola\AppProjectMigrateLargeTables\TimestampConverter;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class TimestampConverterTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/ts-converter-test-' . uniqid();
+        mkdir($this->tempDir, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $files = glob($this->tempDir . '/*');
+        if ($files !== false) {
+            foreach ($files as $file) {
+                unlink($file);
+            }
+        }
+        rmdir($this->tempDir);
+    }
+
+    public function testNoTimestampColumnsSkipsProcessing(): void
+    {
+        $converter = new TimestampConverter(
+            ['id', 'name'],
+            [
+                'id' => [['provider' => 'storage', 'key' => 'KBC.datatype.type', 'value' => 'INTEGER']],
+                'name' => [['provider' => 'storage', 'key' => 'KBC.datatype.type', 'value' => 'VARCHAR']],
+            ],
+            'America/Los_Angeles',
+            new NullLogger(),
+        );
+
+        self::assertFalse($converter->hasTimestampColumns());
+    }
+
+    public function testDetectsTimestampLtzColumn(): void
+    {
+        $converter = new TimestampConverter(
+            ['id', 'created_at'],
+            [
+                'id' => [['provider' => 'storage', 'key' => 'KBC.datatype.type', 'value' => 'INTEGER']],
+                'created_at' => [['provider' => 'storage', 'key' => 'KBC.datatype.type', 'value' => 'TIMESTAMP_LTZ']],
+            ],
+            'America/Los_Angeles',
+            new NullLogger(),
+        );
+
+        self::assertTrue($converter->hasTimestampColumns());
+    }
+
+    public function testDetectsTimestampTzColumn(): void
+    {
+        $converter = new TimestampConverter(
+            ['id', 'updated_at'],
+            [
+                'id' => [['provider' => 'storage', 'key' => 'KBC.datatype.type', 'value' => 'INTEGER']],
+                'updated_at' => [['provider' => 'storage', 'key' => 'KBC.datatype.type', 'value' => 'TIMESTAMP_TZ']],
+            ],
+            'America/Los_Angeles',
+            new NullLogger(),
+        );
+
+        self::assertTrue($converter->hasTimestampColumns());
+    }
+
+    public function testSnowflakeOffsetFormat(): void
+    {
+        $filePath = $this->createGzippedCsv([
+            ['1', '2024-11-14 23:43:22.000 -0800', 'hello'],
+        ]);
+
+        $converter = $this->createConverter(['id', 'ts', 'name'], 'ts', 'TIMESTAMP_LTZ');
+        $converter->processGzippedFile($filePath);
+
+        $rows = $this->readGzippedCsv($filePath);
+        self::assertCount(1, $rows);
+        self::assertSame('1', $rows[0][0]);
+        self::assertSame('2024-11-15 07:43:22', $rows[0][1]);
+        self::assertSame('hello', $rows[0][2]);
+    }
+
+    public function testPlainTimestampUsesSourceTimezone(): void
+    {
+        $filePath = $this->createGzippedCsv([
+            ['1', '2024-11-14 23:43:22.000', 'world'],
+        ]);
+
+        $converter = $this->createConverter(
+            ['id', 'ts', 'name'],
+            'ts',
+            'TIMESTAMP_LTZ',
+            'America/Los_Angeles',
+        );
+        $converter->processGzippedFile($filePath);
+
+        $rows = $this->readGzippedCsv($filePath);
+        self::assertCount(1, $rows);
+        self::assertSame('2024-11-15 07:43:22', $rows[0][1]);
+    }
+
+    public function testPositiveOffset(): void
+    {
+        $filePath = $this->createGzippedCsv([
+            ['1', '2024-11-14 23:43:22.000 +0530'],
+        ]);
+
+        $converter = $this->createConverter(['id', 'ts'], 'ts', 'TIMESTAMP_LTZ');
+        $converter->processGzippedFile($filePath);
+
+        $rows = $this->readGzippedCsv($filePath);
+        self::assertCount(1, $rows);
+        self::assertSame('2024-11-14 18:13:22', $rows[0][1]);
+    }
+
+    public function testUtcOffset(): void
+    {
+        $filePath = $this->createGzippedCsv([
+            ['1', '2024-11-14 23:43:22.000 +0000'],
+        ]);
+
+        $converter = $this->createConverter(['id', 'ts'], 'ts', 'TIMESTAMP_LTZ');
+        $converter->processGzippedFile($filePath);
+
+        $rows = $this->readGzippedCsv($filePath);
+        self::assertCount(1, $rows);
+        self::assertSame('2024-11-14 23:43:22', $rows[0][1]);
+    }
+
+    public function testNoFractionalSecondsWithOffset(): void
+    {
+        $filePath = $this->createGzippedCsv([
+            ['1', '2024-11-14 23:43:22 -0800'],
+        ]);
+
+        $converter = $this->createConverter(['id', 'ts'], 'ts', 'TIMESTAMP_LTZ');
+        $converter->processGzippedFile($filePath);
+
+        $rows = $this->readGzippedCsv($filePath);
+        self::assertCount(1, $rows);
+        self::assertSame('2024-11-15 07:43:22', $rows[0][1]);
+    }
+
+    public function testEmptyValuePreserved(): void
+    {
+        $filePath = $this->createGzippedCsv([
+            ['1', '', 'test'],
+        ]);
+
+        $converter = $this->createConverter(['id', 'ts', 'name'], 'ts', 'TIMESTAMP_LTZ');
+        $converter->processGzippedFile($filePath);
+
+        $rows = $this->readGzippedCsv($filePath);
+        self::assertCount(1, $rows);
+        self::assertSame('', $rows[0][1]);
+    }
+
+    public function testMultipleRowsMixedFormats(): void
+    {
+        $filePath = $this->createGzippedCsv([
+            ['1', '2024-11-14 23:43:22.000 -0800', 'row1'],
+            ['2', '2024-06-15 10:00:00.000 +0000', 'row2'],
+            ['3', '', 'row3'],
+            ['4', '2024-01-01 12:00:00.000 +0530', 'row4'],
+        ]);
+
+        $converter = $this->createConverter(['id', 'ts', 'name'], 'ts', 'TIMESTAMP_LTZ');
+        $converter->processGzippedFile($filePath);
+
+        $rows = $this->readGzippedCsv($filePath);
+        self::assertCount(4, $rows);
+        self::assertSame('2024-11-15 07:43:22', $rows[0][1]);
+        self::assertSame('2024-06-15 10:00:00', $rows[1][1]);
+        self::assertSame('', $rows[2][1]);
+        self::assertSame('2024-01-01 06:30:00', $rows[3][1]);
+    }
+
+    public function testNonTimestampColumnsUnchanged(): void
+    {
+        $filePath = $this->createGzippedCsv([
+            ['some-id-123', '2024-11-14 23:43:22.000 -0800', 'text with, comma'],
+        ]);
+
+        $converter = $this->createConverter(['id', 'ts', 'desc'], 'ts', 'TIMESTAMP_LTZ');
+        $converter->processGzippedFile($filePath);
+
+        $rows = $this->readGzippedCsv($filePath);
+        self::assertCount(1, $rows);
+        self::assertSame('some-id-123', $rows[0][0]);
+        self::assertSame('text with, comma', $rows[0][2]);
+    }
+
+    public function testProcessGzippedSlices(): void
+    {
+        $file1 = $this->createGzippedCsv([
+            ['1', '2024-11-14 23:43:22.000 -0800'],
+        ]);
+        $file2 = $this->createGzippedCsv([
+            ['2', '2024-06-15 10:00:00.000 +0000'],
+        ]);
+
+        $converter = $this->createConverter(['id', 'ts'], 'ts', 'TIMESTAMP_LTZ');
+        $converter->processGzippedSlices([$file1, $file2]);
+
+        $rows1 = $this->readGzippedCsv($file1);
+        $rows2 = $this->readGzippedCsv($file2);
+        self::assertSame('2024-11-15 07:43:22', $rows1[0][1]);
+        self::assertSame('2024-06-15 10:00:00', $rows2[0][1]);
+    }
+
+    private function createConverter(
+        array $columns,
+        string $tsColumn,
+        string $tsType,
+        string $timezone = 'America/Los_Angeles',
+    ): TimestampConverter {
+        $metadata = [];
+        foreach ($columns as $col) {
+            if ($col === $tsColumn) {
+                $metadata[$col] = [['provider' => 'storage', 'key' => 'KBC.datatype.type', 'value' => $tsType]];
+            } else {
+                $metadata[$col] = [['provider' => 'storage', 'key' => 'KBC.datatype.type', 'value' => 'VARCHAR']];
+            }
+        }
+        return new TimestampConverter($columns, $metadata, $timezone, new NullLogger());
+    }
+
+    /**
+     * @param array<int, array<int, string>> $rows
+     */
+    private function createGzippedCsv(array $rows): string
+    {
+        $filePath = $this->tempDir . '/test-' . uniqid() . '.csv.gz';
+        $gz = gzopen($filePath, 'wb');
+        assert($gz !== false);
+        foreach ($rows as $row) {
+            $parts = [];
+            foreach ($row as $field) {
+                if (str_contains($field, ',') || str_contains($field, '"') || str_contains($field, "\n")) {
+                    $parts[] = '"' . str_replace('"', '""', $field) . '"';
+                } else {
+                    $parts[] = $field;
+                }
+            }
+            gzwrite($gz, implode(',', $parts) . "\n");
+        }
+        gzclose($gz);
+        return $filePath;
+    }
+
+    /**
+     * @return array<int, array<int, string>>
+     */
+    private function readGzippedCsv(string $filePath): array
+    {
+        $input = fopen('compress.zlib://' . $filePath, 'r');
+        assert($input !== false);
+        $rows = [];
+        while (($row = fgetcsv($input, 0, ',', '"', '\\')) !== false) {
+            $rows[] = $row;
+        }
+        fclose($input);
+        return $rows;
+    }
+}


### PR DESCRIPTION
# feat: native DuckDB TRY_STRPTIME for TIMESTAMP_LTZ/TZ to UTC conversion

## Summary

Replaces the previous PHP DateTime row-by-row timestamp conversion with DuckDB CLI-based SQL conversion for `TIMESTAMP_LTZ` and `TIMESTAMP_TZ` columns. The converter identifies timestamp columns from storage metadata and applies a COALESCE chain of native DuckDB parsing functions — **no regex on column values**.

**DuckDB conversion logic per timestamp column:**
```sql
CASE WHEN col IS NOT NULL AND col != ''
  THEN COALESCE(
    CAST(timezone('UTC', COALESCE(
      TRY_STRPTIME(col, '%Y-%m-%d %H:%M:%S.%f %z'),              -- fractional seconds + offset
      TRY_STRPTIME(col, '%Y-%m-%d %H:%M:%S %z'),                  -- no fractional + offset
      timezone(sourceTimezone, TRY_STRPTIME(col, '%Y-%m-%d %H:%M:%S.%f')),  -- fractional, no offset
      timezone(sourceTimezone, TRY_STRPTIME(col, '%Y-%m-%d %H:%M:%S'))      -- plain timestamp
    )) AS VARCHAR),
    col   -- fallback: preserve original value if no pattern matches
  )
  ELSE col END
```

Also includes (from the base branch `163-parallel-conversion-types-timezones`): parallel table migration, cross-backend type mapping (Snowflake ↔ BigQuery), GCS large table support, and `sourceTimezone`/`parallelism` config parameters.

## Updates since last revision

**Fixed DuckDB column count mismatch causing crash (job 61144865):**

The CSV export contained 30 columns but table metadata only listed 29. DuckDB was configured with explicit `columns={29 defs}` and rejected rows with `Expected Number of Columns: 29 Found: 30`.

**Root cause:** The code hardcoded column definitions from table metadata, but actual CSV slices can contain extra columns not reflected in metadata.

**Solution:** Added `detectCsvColumnCount()` which reads the first line of the gzipped CSV with `str_getcsv` to determine actual column count, then uses `max(actualColumnCount, metadataColumnCount)` when building column definitions. Extra columns pass through untouched.

**Previous fixes (from earlier commits):**
1. **Outer COALESCE fallback**: Added `COALESCE(CAST(...), col)` to preserve original values when all TRY_STRPTIME patterns fail — prevents header row corruption that caused empty storage imports (job 61133652).
2. **`%g` → `%f`**: DuckDB's `%g` only matches 3-digit milliseconds. `%f` handles any fractional second length including 6-digit microseconds.
3. **Removed `ignore_errors=true`**: Was silently dropping CSV rows that DuckDB couldn't parse.
4. **Added `FORCE_QUOTE *`**: Output CSV now quotes all non-NULL fields, matching Keboola's expected format.
5. **Explicit `timezone()` fallback**: Plain timestamps without offsets use `timezone(sourceTimezone, TRY_STRPTIME(...))` instead of ambiguous `TRY_CAST`.

## Review & Testing Checklist for Human

- [ ] **Three previous production deployments failed** — this is the fourth attempt. Test thoroughly in production before marking as complete. Verify with multiple tables and edge cases.
- [ ] **Column count detection reads only first line** — if CSV rows have variable column counts (some rows with more columns than the first line), those rows will still fail. Verify that Keboola CSV exports have consistent column counts across all rows.
- [ ] **ISO offset format with colon (`-08:00`) is NOT covered by `%z`.** DuckDB's `%z` expects `+HHMM`/`-HHMM` without colon. Values like `2024-11-14 23:43:22.000000-08:00` will fall through to the outer COALESCE and be **preserved as-is** (not converted to UTC). Verify whether Snowflake exports ever produce this format.
- [ ] **Unparseable timestamps pass through unchanged.** If a value looks like a timestamp but doesn't match any pattern, it won't be converted — it'll be preserved as-is. This could mask data quality issues. Consider whether this is acceptable.
- [ ] **No timeout on DuckDB process.** `proc_open` will block indefinitely if DuckDB hangs on malformed input.

### Test Plan
1. Run the component with `{"runtime": {"tag": "1771591380-duckdb-native-tz"}}` on project 2289 (europe-west3 GCP stack)
2. Verify timestamp conversion for tables with `TIMESTAMP_LTZ` columns containing:
   - Snowflake offset format (3-digit ms): `2024-11-14 23:43:22.000 -0800`
   - Snowflake offset format (6-digit µs): `2024-11-14 23:43:22.000000 -0800`
   - Plain timestamps: `2024-11-14 23:43:22.000`
   - Empty values
3. **Verify data actually loads to Storage** (previous three attempts had various failures)
4. Check that header rows are preserved correctly
5. Verify tables with extra columns beyond metadata are handled correctly

### Notes
- 14 PHPUnit tests added for `TimestampConverter` — all pass locally (including new test for extra columns scenario)
- DuckDB CLI v1.1.3 installed in Dockerfile with ICU extension pre-loaded
- Tested locally with real Keboola CSV export data (header + 1 data row with 29 columns, and slice with 30 columns) — both handled correctly
- Previous regex-based approach (v3/v4 tags) caused component hangs — this PR starts fresh from base tag `163-parallel-conversion-types-timezones`

---

**Link to Devin run:** https://app.devin.ai/sessions/f93f270be2c84fab9509fd0e5fb3bd17  
**Requested by:** @yustme
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/keboola/app-project-migrate-large-tables/pull/48" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->