### PR TITLE
[AJDA-2415] Native types — Snowflake ↔ BigQuery conversion

### DIFF
--- a/src/StorageModifier.php
+++ b/src/StorageModifier.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Keboola\AppProjectMigrateLargeTables;
 
 use Keboola\Csv\CsvFile;
+use Keboola\Datatype\Definition\BaseType;
+use Keboola\Datatype\Definition\Bigquery;
+use Keboola\Datatype\Definition\Snowflake;
 use Keboola\StorageApi\Client;
 use Keboola\StorageApi\ClientException;
 use Keboola\StorageApi\Exception as StorageApiException;
@@ -15,6 +18,9 @@ use Keboola\Temp\Temp;
 class StorageModifier
 {
     private Temp $tmp;
+
+    /** @var array<string, string> */
+    private array $bucketBackendCache = [];
 
     public function __construct(readonly Client $client)
     {
@@ -59,45 +65,44 @@ class StorageModifier
 
     private function createTypedTable(array $tableInfo): void
     {
+        $sourceBackend = $tableInfo['bucket']['backend'];
+        $destinationBackend = $this->getDestinationBucketBackend($tableInfo['bucket']['id']);
+
         $columns = [];
-        foreach ($tableInfo['columns'] as $column) {
-            $columns[$column] = [];
-        }
-        foreach ($tableInfo['columnMetadata'] ?? [] as $columnName => $column) {
-            $columnName = (string) $columnName;
-            $columnMetadata = [];
-            foreach ($column as $metadata) {
-                if ($metadata['provider'] !== 'storage') {
-                    continue;
+        foreach ($tableInfo['definition']['columns'] as $columnDef) {
+            $columnName = $columnDef['name'];
+            $basetype = $columnDef['basetype'] ?? null;
+            $nullable = (bool) $columnDef['definition']['nullable'];
+
+            if ($sourceBackend !== $destinationBackend) {
+                $definition = $this->buildCrossBackendDefinition($destinationBackend, $basetype, $nullable);
+            } else {
+                $definition = [
+                    'type' => $columnDef['definition']['type'],
+                    'nullable' => $nullable,
+                ];
+                if (isset($columnDef['definition']['length'])) {
+                    $definition['length'] = $columnDef['definition']['length'];
                 }
-                $columnMetadata[$metadata['key']] = $metadata['value'];
+                if (isset($columnDef['definition']['default'])) {
+                    $definition['default'] = $columnDef['definition']['default'];
+                }
             }
 
-            $definition = [
-                'type' => $columnMetadata['KBC.datatype.type'],
-                'nullable' => $columnMetadata['KBC.datatype.nullable'] === '1',
-            ];
-            if (isset($columnMetadata['KBC.datatype.length'])) {
-                $definition['length'] = $columnMetadata['KBC.datatype.length'];
-            }
-            if (isset($columnMetadata['KBC.datatype.default'])) {
-                $definition['default'] = $columnMetadata['KBC.datatype.default'];
-            }
-
-            $columns[$columnName] = [
+            $columns[] = [
                 'name' => $columnName,
                 'definition' => $definition,
-                'basetype' => $columnMetadata['KBC.datatype.basetype'],
+                'basetype' => $basetype,
             ];
         }
 
         $data = [
             'name' => $tableInfo['name'],
             'primaryKeysNames' => $tableInfo['primaryKey'],
-            'columns' => array_values($columns),
+            'columns' => $columns,
         ];
 
-        if ($tableInfo['bucket']['backend'] === 'synapse') {
+        if ($sourceBackend === 'synapse') {
             $data['distribution'] = [
                 'type' => $tableInfo['distributionType'],
                 'distributionColumnsNames' => $tableInfo['distributionKey'],
@@ -123,6 +128,34 @@ class StorageModifier
             }
             throw $e;
         }
+    }
+
+    private function buildCrossBackendDefinition(string $destinationBackend, ?string $basetype, bool $nullable): array
+    {
+        $effectiveBasetype = ($basetype !== null && BaseType::isValid(strtoupper($basetype)))
+            ? strtoupper($basetype)
+            : BaseType::STRING;
+
+        $nativeType = match ($destinationBackend) {
+            'bigquery' => Bigquery::getTypeByBasetype($effectiveBasetype),
+            'snowflake' => Snowflake::getTypeByBasetype($effectiveBasetype),
+            default => $effectiveBasetype,
+        };
+
+        return [
+            'type' => $nativeType,
+            'nullable' => $nullable,
+        ];
+    }
+
+    private function getDestinationBucketBackend(string $bucketId): string
+    {
+        if (!array_key_exists($bucketId, $this->bucketBackendCache)) {
+            $bucket = $this->client->getBucket($bucketId);
+            $this->bucketBackendCache[$bucketId] = $bucket['backend'];
+        }
+
+        return $this->bucketBackendCache[$bucketId];
     }
 
     private function restoreTableColumnsMetadata(array $tableInfo, string $tableId, Metadata $metadataClient): void

--- a/tests/phpunit/StorageModifierTest.php
+++ b/tests/phpunit/StorageModifierTest.php
@@ -1,0 +1,382 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AppProjectMigrateLargeTables\Tests;
+
+use Keboola\AppProjectMigrateLargeTables\StorageModifier;
+use Keboola\StorageApi\Client;
+use PHPUnit\Framework\TestCase;
+
+class StorageModifierTest extends TestCase
+{
+    private function buildColumnDef(
+        string $name,
+        string $type,
+        ?string $basetype,
+        bool $nullable = true,
+        ?string $length = null,
+        ?string $default = null,
+    ): array {
+        $definition = [
+            'type' => $type,
+            'nullable' => $nullable,
+        ];
+        if ($length !== null) {
+            $definition['length'] = $length;
+        }
+        if ($default !== null) {
+            $definition['default'] = $default;
+        }
+
+        return [
+            'name' => $name,
+            'basetype' => $basetype,
+            'definition' => $definition,
+        ];
+    }
+
+    private function buildTableInfo(
+        string $sourceBackend,
+        string $bucketId,
+        array $columns,
+        array $primaryKey = [],
+    ): array {
+        return [
+            'id' => sprintf('%s.my_table', $bucketId),
+            'name' => 'my_table',
+            'isTyped' => true,
+            'primaryKey' => $primaryKey,
+            'bucket' => [
+                'id' => $bucketId,
+                'backend' => $sourceBackend,
+            ],
+            'definition' => [
+                'columns' => $columns,
+            ],
+            'metadata' => [],
+            'columnMetadata' => [],
+        ];
+    }
+
+    public function testCreateTypedTableSameBackendPreservesNativeTypeWithLengthAndDefault(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->expects($this->once())
+            ->method('getBucket')
+            ->with($bucketId)
+            ->willReturn(['backend' => 'snowflake']);
+
+        $capturedData = null;
+        $client->expects($this->once())
+            ->method('createTableDefinition')
+            ->with($bucketId, $this->callback(function (array $data) use (&$capturedData) {
+                $capturedData = $data;
+                return true;
+            }));
+
+        $modifier = new StorageModifier($client);
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'snowflake',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('id', 'INTEGER', 'INTEGER', false),
+                $this->buildColumnDef('name', 'VARCHAR', 'STRING', true, '255', 'unknown'),
+                $this->buildColumnDef('amount', 'NUMBER', 'NUMERIC', true, '18,2'),
+            ],
+        ));
+
+        $this->assertNotNull($capturedData);
+        $this->assertSame([
+            [
+                'name' => 'id',
+                'definition' => ['type' => 'INTEGER', 'nullable' => false],
+                'basetype' => 'INTEGER',
+            ],
+            [
+                'name' => 'name',
+                'definition' => ['type' => 'VARCHAR', 'nullable' => true, 'length' => '255', 'default' => 'unknown'],
+                'basetype' => 'STRING',
+            ],
+            [
+                'name' => 'amount',
+                'definition' => ['type' => 'NUMBER', 'nullable' => true, 'length' => '18,2'],
+                'basetype' => 'NUMERIC',
+            ],
+        ], $capturedData['columns']);
+    }
+
+    public function testCreateTypedTableCrossBackendSnowflakeToBigquery(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->with($bucketId)
+            ->willReturn(['backend' => 'bigquery']);
+
+        $capturedData = null;
+        $client->expects($this->once())
+            ->method('createTableDefinition')
+            ->with($bucketId, $this->callback(function (array $data) use (&$capturedData) {
+                $capturedData = $data;
+                return true;
+            }));
+
+        $modifier = new StorageModifier($client);
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'snowflake',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('id', 'INTEGER', 'INTEGER', false),
+                $this->buildColumnDef('name', 'VARCHAR', 'STRING', true, '255'),
+                $this->buildColumnDef('price', 'FLOAT', 'FLOAT', true),
+                $this->buildColumnDef('active', 'BOOLEAN', 'BOOLEAN', true),
+                $this->buildColumnDef('created', 'TIMESTAMP', 'TIMESTAMP', true),
+                $this->buildColumnDef('date_col', 'DATE', 'DATE', true),
+                $this->buildColumnDef('amount', 'NUMBER', 'NUMERIC', true),
+            ],
+        ));
+
+        $expectedColumns = [
+            ['name' => 'id', 'definition' => ['type' => 'INT64', 'nullable' => false], 'basetype' => 'INTEGER'],
+            ['name' => 'name', 'definition' => ['type' => 'STRING', 'nullable' => true], 'basetype' => 'STRING'],
+            ['name' => 'price', 'definition' => ['type' => 'FLOAT64', 'nullable' => true], 'basetype' => 'FLOAT'],
+            ['name' => 'active', 'definition' => ['type' => 'BOOL', 'nullable' => true], 'basetype' => 'BOOLEAN'],
+            [
+                'name' => 'created',
+                'definition' => ['type' => 'TIMESTAMP', 'nullable' => true],
+                'basetype' => 'TIMESTAMP',
+            ],
+            ['name' => 'date_col', 'definition' => ['type' => 'DATE', 'nullable' => true], 'basetype' => 'DATE'],
+            ['name' => 'amount', 'definition' => ['type' => 'NUMERIC', 'nullable' => true], 'basetype' => 'NUMERIC'],
+        ];
+
+        $this->assertNotNull($capturedData);
+        $this->assertSame($expectedColumns, $capturedData['columns']);
+    }
+
+    public function testCreateTypedTableCrossBackendBigqueryToSnowflake(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->with($bucketId)
+            ->willReturn(['backend' => 'snowflake']);
+
+        $capturedData = null;
+        $client->expects($this->once())
+            ->method('createTableDefinition')
+            ->with($bucketId, $this->callback(function (array $data) use (&$capturedData) {
+                $capturedData = $data;
+                return true;
+            }));
+
+        $modifier = new StorageModifier($client);
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'bigquery',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('id', 'INT64', 'INTEGER', false),
+                $this->buildColumnDef('name', 'STRING', 'STRING', true),
+                $this->buildColumnDef('price', 'FLOAT64', 'FLOAT', true),
+                $this->buildColumnDef('active', 'BOOL', 'BOOLEAN', true),
+                $this->buildColumnDef('created', 'TIMESTAMP', 'TIMESTAMP', true),
+                $this->buildColumnDef('amount', 'NUMERIC', 'NUMERIC', true),
+            ],
+        ));
+
+        $expectedColumns = [
+            ['name' => 'id', 'definition' => ['type' => 'INTEGER', 'nullable' => false], 'basetype' => 'INTEGER'],
+            ['name' => 'name', 'definition' => ['type' => 'VARCHAR', 'nullable' => true], 'basetype' => 'STRING'],
+            ['name' => 'price', 'definition' => ['type' => 'FLOAT', 'nullable' => true], 'basetype' => 'FLOAT'],
+            [
+                'name' => 'active',
+                'definition' => ['type' => 'BOOLEAN', 'nullable' => true],
+                'basetype' => 'BOOLEAN',
+            ],
+            [
+                'name' => 'created',
+                'definition' => ['type' => 'TIMESTAMP', 'nullable' => true],
+                'basetype' => 'TIMESTAMP',
+            ],
+            ['name' => 'amount', 'definition' => ['type' => 'NUMBER', 'nullable' => true], 'basetype' => 'NUMERIC'],
+        ];
+
+        $this->assertNotNull($capturedData);
+        $this->assertSame($expectedColumns, $capturedData['columns']);
+    }
+
+    public function testCreateTypedTableCrossBackendNullBasetypeFallsBackToString(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->willReturn(['backend' => 'bigquery']);
+
+        $capturedData = null;
+        $client->method('createTableDefinition')
+            ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
+                $capturedData = $data;
+            });
+
+        $modifier = new StorageModifier($client);
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'snowflake',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('col', 'VARIANT', null, true),
+            ],
+        ));
+
+        $this->assertNotNull($capturedData);
+        $this->assertSame('STRING', $capturedData['columns'][0]['definition']['type']);
+    }
+
+    public function testCreateTypedTableCrossBackendUnknownBasetypeFallsBackToString(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->willReturn(['backend' => 'snowflake']);
+
+        $capturedData = null;
+        $client->method('createTableDefinition')
+            ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
+                $capturedData = $data;
+            });
+
+        $modifier = new StorageModifier($client);
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'bigquery',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('col', 'JSON', 'SOME_UNKNOWN_TYPE', true),
+            ],
+        ));
+
+        $this->assertNotNull($capturedData);
+        $this->assertSame('VARCHAR', $capturedData['columns'][0]['definition']['type']);
+    }
+
+    public function testCreateTypedTableCrossBackendDoesNotCopyLengthOrDefault(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->willReturn(['backend' => 'bigquery']);
+
+        $capturedData = null;
+        $client->method('createTableDefinition')
+            ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
+                $capturedData = $data;
+            });
+
+        $modifier = new StorageModifier($client);
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'snowflake',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('name', 'VARCHAR', 'STRING', true, '255', 'foo'),
+            ],
+        ));
+
+        $this->assertNotNull($capturedData);
+        $columnDef = $capturedData['columns'][0]['definition'];
+        $this->assertArrayNotHasKey('length', $columnDef);
+        $this->assertArrayNotHasKey('default', $columnDef);
+    }
+
+    public function testGetDestinationBucketBackendIsCachedAcrossMultipleTables(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        // getBucket should only be called once even when creating multiple tables in the same bucket
+        $client->expects($this->once())
+            ->method('getBucket')
+            ->with($bucketId)
+            ->willReturn(['backend' => 'snowflake']);
+
+        $client->method('createTableDefinition');
+
+        $modifier = new StorageModifier($client);
+
+        $tableInfo = $this->buildTableInfo(
+            sourceBackend: 'snowflake',
+            bucketId: $bucketId,
+            columns: [$this->buildColumnDef('id', 'INTEGER', 'INTEGER', false)],
+        );
+
+        $tableInfo2 = array_merge($tableInfo, ['name' => 'my_table_2', 'id' => $bucketId . '.my_table_2']);
+
+        $modifier->createTable($tableInfo);
+        $modifier->createTable($tableInfo2);
+    }
+
+    public function testCreateTypedTableWithPrimaryKey(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->willReturn(['backend' => 'snowflake']);
+
+        $capturedData = null;
+        $client->method('createTableDefinition')
+            ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
+                $capturedData = $data;
+            });
+
+        $modifier = new StorageModifier($client);
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'snowflake',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('id', 'INTEGER', 'INTEGER', false),
+                $this->buildColumnDef('name', 'VARCHAR', 'STRING', true),
+            ],
+            primaryKey: ['id'],
+        ));
+
+        $this->assertNotNull($capturedData);
+        $this->assertSame(['id'], $capturedData['primaryKeysNames']);
+        $this->assertSame('my_table', $capturedData['name']);
+    }
+
+    public function testCreateTypedTableWithUnknownDestinationBackendUsesBasetypeAsType(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->willReturn(['backend' => 'exasol']);
+
+        $capturedData = null;
+        $client->method('createTableDefinition')
+            ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
+                $capturedData = $data;
+            });
+
+        $modifier = new StorageModifier($client);
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'snowflake',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('id', 'INTEGER', 'INTEGER', false),
+                $this->buildColumnDef('name', 'VARCHAR', 'STRING', true),
+            ],
+        ));
+
+        $this->assertNotNull($capturedData);
+        // For unknown backends, basetype is used directly as type
+        $this->assertSame('INTEGER', $capturedData['columns'][0]['definition']['type']);
+        $this->assertSame('STRING', $capturedData['columns'][1]['definition']['type']);
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces `columnMetadata` parsing with `definition.columns` from SAPI response
- Detects source vs destination backend; for cross-backend migrations (e.g. Snowflake → BigQuery) converts native types via basetype using `keboola/php-datatypes`
- Falls back to `STRING` when basetype is null or unknown
- Caches destination bucket backend to avoid redundant API calls
- `nullable` always read from `definition.columns[n].definition.nullable` regardless of path

## Test plan
- [x] Snowflake → BigQuery: table with VARCHAR columns creates as STRING in BQ
- [x] BigQuery → BigQuery: native types passed through unchanged
- [x] Snowflake → Snowflake: native types passed through unchanged
- [x] Null basetype falls back to STRING