### PR TITLE
[AJDA-2416] Fix datetime timezone — pass timezone=UTC to SAPI client for Snowflake→BigQuery migration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "php": "^8.2",
         "keboola/db-adapter-snowflake": "^1.5",
         "keboola/php-component": "^9.4",
-        "keboola/storage-api-client": "^18.2",
+        "keboola/php-datatypes": "^7.0",
+        "keboola/storage-api-client": "^18.7",
         "symfony/process": "^6.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c30fe65e81b88fd9a72eb5333465f126",
+    "content-hash": "308e3de505f26786c57000aac7196684",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -340,56 +340,6 @@
                 "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.47.1"
             },
             "time": "2025-07-09T15:26:02+00:00"
-        },
-        {
-            "name": "google/cloud-bigquery-analyticshub",
-            "version": "v0.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/googleapis/google-cloud-php-bigquery-analyticshub.git",
-                "reference": "90609322f03c9d95b7ac56abd0a786255e10a4cd"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-cloud-php-bigquery-analyticshub/zipball/90609322f03c9d95b7ac56abd0a786255e10a4cd",
-                "reference": "90609322f03c9d95b7ac56abd0a786255e10a4cd",
-                "shasum": ""
-            },
-            "require": {
-                "google/gax": "^1.19.1",
-                "php": ">=7.4"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "suggest": {
-                "ext-grpc": "Enables use of gRPC, a universal high-performance RPC framework created by Google.",
-                "ext-protobuf": "Provides a significant increase in throughput over the pure PHP protobuf implementation. See https://cloud.google.com/php/grpc for installation instructions."
-            },
-            "type": "library",
-            "extra": {
-                "component": {
-                    "id": "cloud-bigquery-analyticshub",
-                    "path": "BigQueryAnalyticsHub",
-                    "entry": null,
-                    "target": "googleapis/google-cloud-php-bigquery-analyticshub.git"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Google\\Cloud\\BigQuery\\AnalyticsHub\\": "src",
-                    "GPBMetadata\\Google\\Cloud\\Bigquery\\Analyticshub\\": "metadata"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "Apache-2.0"
-            ],
-            "description": "Google Cloud BigQuery Analytics Hub Client for PHP",
-            "support": {
-                "source": "https://github.com/googleapis/google-cloud-php-bigquery-analyticshub/tree/v0.2.2"
-            },
-            "time": "2023-07-07T20:46:38+00:00"
         },
         {
             "name": "google/cloud-core",
@@ -1373,57 +1323,41 @@
         },
         {
             "name": "keboola/storage-api-client",
-            "version": "v18.2.6",
+            "version": "v18.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/keboola/storage-api-php-client.git",
-                "reference": "df43573f1d29d418dd5dd74a832b4a68bf14f1ea"
+                "reference": "b70db64dd1cca95f451447fe4e5412654f5dd395"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/keboola/storage-api-php-client/zipball/df43573f1d29d418dd5dd74a832b4a68bf14f1ea",
-                "reference": "df43573f1d29d418dd5dd74a832b4a68bf14f1ea",
+                "url": "https://api.github.com/repos/keboola/storage-api-php-client/zipball/b70db64dd1cca95f451447fe4e5412654f5dd395",
+                "reference": "b70db64dd1cca95f451447fe4e5412654f5dd395",
                 "shasum": ""
             },
             "require": {
                 "aws/aws-sdk-php": "~3.2",
                 "ext-json": "*",
-                "google/cloud-bigquery-analyticshub": "^0.2.2",
                 "google/cloud-storage": "^1.27",
                 "guzzlehttp/guzzle": "~7.0",
                 "keboola/csv": "^1",
-                "keboola/php-datatypes": "^7.0",
                 "microsoft/azure-storage-blob": "^1.5",
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "psr/log": "^1.1|^2.0|^3.0",
                 "symfony/filesystem": "^7.0||^6.0||^5.0||^4.0",
                 "symfony/process": "^7.0||^6.0||^5.0||^4.0"
             },
             "require-dev": {
-                "brianium/paratest": "2.*|6.*",
                 "ext-curl": "*",
-                "ext-pdo": "*",
-                "ext-pdo_pgsql": "*",
-                "keboola/coding-standard": "^15.0",
-                "keboola/kbc-manage-api-php-client": "^9.0",
-                "keboola/php-csv-db-import": "^6",
-                "keboola/phpunit-retry-annotations": "^0.5",
-                "keboola/retry": "^0.5.0",
-                "keboola/table-backend-utils": ">=2.9.0",
-                "phpstan/phpstan": "^1",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpunit/phpunit": "^7.0|^8.0|^9.0",
-                "rector/rector": "^0.12.23",
-                "squizlabs/php_codesniffer": "^3",
-                "tomasfejfar/phpstan-phpunit": "^0.1.0"
+                "phpunit/phpunit": "^9.0|^10"
             },
             "type": "library",
             "autoload": {
                 "files": [
                     "src/Keboola/StorageApi/createSimpleJobPollDelay.php"
                 ],
-                "psr-0": {
-                    "Keboola\\StorageApi": "src/"
+                "psr-4": {
+                    "Keboola\\StorageApi\\": "src/Keboola/StorageApi/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1434,9 +1368,9 @@
             "homepage": "http://keboola.com",
             "support": {
                 "issues": "https://github.com/keboola/storage-api-php-client/issues",
-                "source": "https://github.com/keboola/storage-api-php-client/tree/v18.2.6"
+                "source": "https://github.com/keboola/storage-api-php-client/tree/v18.7.0"
             },
-            "time": "2025-08-01T10:35:48+00:00"
+            "time": "2026-02-26T08:21:47+00:00"
         },
         {
             "name": "microsoft/azure-storage-blob",

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -23,7 +23,7 @@ class SapiMigrate implements MigrateInterface
     /** @var string[] $bucketsExist */
     private array $bucketsExist = [];
 
-    /** @var string[] $destinationBackendCache */
+    /** @var array<string, string> $destinationBackendCache */
     private array $destinationBackendCache = [];
 
     public function __construct(
@@ -199,7 +199,9 @@ class SapiMigrate implements MigrateInterface
         ];
 
         $sourceBucket = $sourceTableInfo['bucket'];
-        assert(is_array($sourceBucket));
+        if (!is_array($sourceBucket)) {
+            return $options;
+        }
         $sourceBackend = (string) $sourceBucket['backend'];
         if ($sourceBackend === 'snowflake'
             && $this->getDestinationBucketBackend((string) $sourceBucket['id']) === 'bigquery'
@@ -214,7 +216,7 @@ class SapiMigrate implements MigrateInterface
     {
         if (!array_key_exists($bucketId, $this->destinationBackendCache)) {
             $bucket = $this->targetClient->getBucket($bucketId);
-            $this->destinationBackendCache[$bucketId] = $bucket['backend'];
+            $this->destinationBackendCache[$bucketId] = (string) ($bucket['backend'] ?? '');
         }
 
         return $this->destinationBackendCache[$bucketId];

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -23,6 +23,9 @@ class SapiMigrate implements MigrateInterface
     /** @var string[] $bucketsExist */
     private array $bucketsExist = [];
 
+    /** @var string[] $destinationBackendCache */
+    private array $destinationBackendCache = [];
+
     public function __construct(
         private readonly Client $sourceClient,
         private readonly Client $targetClient,
@@ -98,10 +101,10 @@ class SapiMigrate implements MigrateInterface
         }
 
         $this->logger->info(sprintf('Exporting table %s', $sourceTableInfo['id']));
-        $file = $this->sourceClient->exportTableAsync($sourceTableInfo['id'], [
-            'gzip' => true,
-            'includeInternalTimestamp' => $config->preserveTimestamp(),
-        ]);
+        $file = $this->sourceClient->exportTableAsync(
+            $sourceTableInfo['id'],
+            $this->buildExportOptions($sourceTableInfo, $config),
+        );
 
         $sourceFileId = $file['file']['id'];
         $sourceFileInfo = $this->sourceClient->getFile($sourceFileId);
@@ -185,5 +188,35 @@ class SapiMigrate implements MigrateInterface
             );
         }
         return $listTables;
+    }
+
+    /** @param array<string, mixed> $sourceTableInfo */
+    private function buildExportOptions(array $sourceTableInfo, Config $config): array
+    {
+        $options = [
+            'gzip' => true,
+            'includeInternalTimestamp' => $config->preserveTimestamp(),
+        ];
+
+        $sourceBucket = $sourceTableInfo['bucket'];
+        assert(is_array($sourceBucket));
+        $sourceBackend = (string) $sourceBucket['backend'];
+        if ($sourceBackend === 'snowflake'
+            && $this->getDestinationBucketBackend((string) $sourceBucket['id']) === 'bigquery'
+        ) {
+            $options['timezone'] = 'UTC';
+        }
+
+        return $options;
+    }
+
+    private function getDestinationBucketBackend(string $bucketId): string
+    {
+        if (!array_key_exists($bucketId, $this->destinationBackendCache)) {
+            $bucket = $this->targetClient->getBucket($bucketId);
+            $this->destinationBackendCache[$bucketId] = $bucket['backend'];
+        }
+
+        return $this->destinationBackendCache[$bucketId];
     }
 }

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -202,9 +202,13 @@ class SapiMigrate implements MigrateInterface
         if (!is_array($sourceBucket)) {
             return $options;
         }
-        $sourceBackend = (string) $sourceBucket['backend'];
+        $sourceBackend = (string) ($sourceBucket['backend'] ?? '');
+        $sourceBucketId = (string) ($sourceBucket['id'] ?? '');
+        if ($sourceBackend === '' || $sourceBucketId === '') {
+            return $options;
+        }
         if ($sourceBackend === 'snowflake'
-            && $this->getDestinationBucketBackend((string) $sourceBucket['id']) === 'bigquery'
+            && $this->getDestinationBucketBackend($sourceBucketId) === 'bigquery'
         ) {
             $options['timezone'] = 'UTC';
         }

--- a/tests/phpunit/SapiMigrateTest.php
+++ b/tests/phpunit/SapiMigrateTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AppProjectMigrateLargeTables\Tests;
+
+use Keboola\AppProjectMigrateLargeTables\Config;
+use Keboola\AppProjectMigrateLargeTables\Configuration\ConfigDefinition;
+use Keboola\AppProjectMigrateLargeTables\Strategy\SapiMigrate;
+use Keboola\StorageApi\Client;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class SapiMigrateTest extends TestCase
+{
+    private function buildConfig(array $migrateTables = []): Config
+    {
+        $params = [
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+        ];
+        if ($migrateTables !== []) {
+            $params['tables'] = $migrateTables;
+        }
+
+        return new Config(['parameters' => $params], new ConfigDefinition());
+    }
+
+    private function buildTableInfo(string $sourceBackend, string $tableId = 'in.c-test.table'): array
+    {
+        return [
+            'id' => $tableId,
+            'name' => 'table',
+            'columns' => ['id', 'name'],
+            'isAlias' => false,
+            'primaryKey' => [],
+            'isTyped' => false,
+            'bucket' => [
+                'id' => 'in.c-test',
+                'stage' => 'in',
+                'backend' => $sourceBackend,
+            ],
+        ];
+    }
+
+    private function buildFileInfo(bool $isSliced = false, string $provider = 'aws'): array
+    {
+        return [
+            'id' => 123,
+            'name' => 'table.csv',
+            'provider' => $provider,
+            'isSliced' => $isSliced,
+            'sizeBytes' => 1000,
+        ];
+    }
+
+    public function testExportPassesTimezoneUtcForSnowflakeToBigquery(): void
+    {
+        $sourceClient = $this->createMock(Client::class);
+        $targetClient = $this->createMock(Client::class);
+
+        $tableInfo = $this->buildTableInfo('snowflake');
+        $fileInfo = $this->buildFileInfo();
+
+        $sourceClient->method('getTable')->willReturn($tableInfo);
+        $sourceClient->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
+        $sourceClient->method('getFile')->willReturn($fileInfo);
+        $sourceClient->method('downloadFile');
+
+        $targetClient->method('bucketExists')->willReturn(true);
+        $targetClient->method('tableExists')->willReturn(false);
+        $targetClient->method('getBucket')->willReturn(['backend' => 'bigquery']);
+        $targetClient->method('uploadFile')->willReturn(456);
+        $targetClient->method('writeTableAsyncDirect');
+        $targetClient->method('createTableDefinition');
+
+        $sourceClient->expects($this->once())
+            ->method('exportTableAsync')
+            ->with(
+                $tableInfo['id'],
+                $this->arrayHasKey('timezone'),
+            );
+
+        $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
+        $migrate->migrate($this->buildConfig(['in.c-test.table']));
+    }
+
+    public function testExportTimezoneValueIsUtcForSnowflakeToBigquery(): void
+    {
+        $sourceClient = $this->createMock(Client::class);
+        $targetClient = $this->createMock(Client::class);
+
+        $tableInfo = $this->buildTableInfo('snowflake');
+        $fileInfo = $this->buildFileInfo();
+
+        $sourceClient->method('getTable')->willReturn($tableInfo);
+        $sourceClient->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
+        $sourceClient->method('getFile')->willReturn($fileInfo);
+        $sourceClient->method('downloadFile');
+
+        $targetClient->method('bucketExists')->willReturn(true);
+        $targetClient->method('tableExists')->willReturn(false);
+        $targetClient->method('getBucket')->willReturn(['backend' => 'bigquery']);
+        $targetClient->method('uploadFile')->willReturn(456);
+        $targetClient->method('writeTableAsyncDirect');
+
+        $sourceClient->expects($this->once())
+            ->method('exportTableAsync')
+            ->with(
+                $tableInfo['id'],
+                $this->callback(fn(array $options) => isset($options['timezone']) && $options['timezone'] === 'UTC'),
+            );
+
+        $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
+        $migrate->migrate($this->buildConfig(['in.c-test.table']));
+    }
+
+    public function testExportDoesNotPassTimezoneForSnowflakeToSnowflake(): void
+    {
+        $sourceClient = $this->createMock(Client::class);
+        $targetClient = $this->createMock(Client::class);
+
+        $tableInfo = $this->buildTableInfo('snowflake');
+        $fileInfo = $this->buildFileInfo();
+
+        $sourceClient->method('getTable')->willReturn($tableInfo);
+        $sourceClient->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
+        $sourceClient->method('getFile')->willReturn($fileInfo);
+        $sourceClient->method('downloadFile');
+
+        $targetClient->method('bucketExists')->willReturn(true);
+        $targetClient->method('tableExists')->willReturn(false);
+        $targetClient->method('getBucket')->willReturn(['backend' => 'snowflake']);
+        $targetClient->method('uploadFile')->willReturn(456);
+        $targetClient->method('writeTableAsyncDirect');
+
+        $sourceClient->expects($this->once())
+            ->method('exportTableAsync')
+            ->with(
+                $tableInfo['id'],
+                $this->callback(fn(array $options) => !isset($options['timezone'])),
+            );
+
+        $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
+        $migrate->migrate($this->buildConfig(['in.c-test.table']));
+    }
+
+    public function testExportDoesNotPassTimezoneForBigquerySource(): void
+    {
+        $sourceClient = $this->createMock(Client::class);
+        $targetClient = $this->createMock(Client::class);
+
+        $tableInfo = $this->buildTableInfo('bigquery');
+        $fileInfo = $this->buildFileInfo();
+
+        $sourceClient->method('getTable')->willReturn($tableInfo);
+        $sourceClient->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
+        $sourceClient->method('getFile')->willReturn($fileInfo);
+        $sourceClient->method('downloadFile');
+
+        $targetClient->method('bucketExists')->willReturn(true);
+        $targetClient->method('tableExists')->willReturn(false);
+        $targetClient->method('uploadFile')->willReturn(456);
+        $targetClient->method('writeTableAsyncDirect');
+
+        $sourceClient->expects($this->once())
+            ->method('exportTableAsync')
+            ->with(
+                $tableInfo['id'],
+                $this->callback(fn(array $options) => !isset($options['timezone'])),
+            );
+
+        $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
+        $migrate->migrate($this->buildConfig(['in.c-test.table']));
+    }
+
+    public function testDestinationBucketBackendIsCachedAcrossMultipleTables(): void
+    {
+        $sourceClient = $this->createMock(Client::class);
+        $targetClient = $this->createMock(Client::class);
+
+        $tableInfo1 = $this->buildTableInfo('snowflake', 'in.c-test.table1');
+        $tableInfo2 = $this->buildTableInfo('snowflake', 'in.c-test.table2');
+        $fileInfo = $this->buildFileInfo();
+
+        $sourceClient->method('getTable')->willReturnOnConsecutiveCalls($tableInfo1, $tableInfo2);
+        $sourceClient->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
+        $sourceClient->method('getFile')->willReturn($fileInfo);
+        $sourceClient->method('downloadFile');
+
+        $targetClient->method('bucketExists')->willReturn(true);
+        $targetClient->method('tableExists')->willReturn(false);
+        // getBucket should be called only once due to caching
+        $targetClient->expects($this->once())
+            ->method('getBucket')
+            ->willReturn(['backend' => 'bigquery']);
+        $targetClient->method('uploadFile')->willReturn(456);
+        $targetClient->method('writeTableAsyncDirect');
+
+        $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
+        $migrate->migrate($this->buildConfig(['in.c-test.table1', 'in.c-test.table2']));
+    }
+}

--- a/tests/phpunit/SapiMigrateTest.php
+++ b/tests/phpunit/SapiMigrateTest.php
@@ -62,16 +62,17 @@ class SapiMigrateTest extends TestCase
         $tableInfo = $this->buildTableInfo('snowflake');
         $fileInfo = $this->buildFileInfo();
 
-        $sourceClient->method('getTable')->willReturn($tableInfo);
-        $sourceClient->method('getFile')->willReturn($fileInfo);
-        $sourceClient->method('downloadFile');
+        $sourceClient->expects($this->once())->method('getTable')->with($tableInfo['id'])->willReturn($tableInfo);
+        $sourceClient->expects($this->once())->method('getFile')->with(123)->willReturn($fileInfo);
+        $sourceClient->expects($this->once())->method('downloadFile');
 
-        $targetClient->method('bucketExists')->willReturn(true);
-        $targetClient->method('tableExists')->willReturn(false);
-        $targetClient->method('getBucket')->willReturn(['backend' => 'bigquery']);
-        $targetClient->method('uploadFile')->willReturn(456);
-        $targetClient->method('writeTableAsyncDirect');
-        $targetClient->method('createTableDefinition');
+        $targetClient->expects($this->once())->method('bucketExists')->with('in.c-test')->willReturn(true);
+        $targetClient->expects($this->once())->method('tableExists')->with($tableInfo['id'])->willReturn(false);
+        $targetClient->expects($this->once())->method('getBucket')
+            ->with('in.c-test')->willReturn(['backend' => 'bigquery']);
+        $targetClient->expects($this->once())->method('uploadFile')->willReturn(456);
+        $targetClient->expects($this->once())->method('writeTableAsyncDirect');
+        $targetClient->expects($this->never())->method('createTableDefinition');
 
         $sourceClient->expects($this->once())
             ->method('exportTableAsync')
@@ -93,15 +94,16 @@ class SapiMigrateTest extends TestCase
         $tableInfo = $this->buildTableInfo('snowflake');
         $fileInfo = $this->buildFileInfo();
 
-        $sourceClient->method('getTable')->willReturn($tableInfo);
-        $sourceClient->method('getFile')->willReturn($fileInfo);
-        $sourceClient->method('downloadFile');
+        $sourceClient->expects($this->once())->method('getTable')->with($tableInfo['id'])->willReturn($tableInfo);
+        $sourceClient->expects($this->once())->method('getFile')->with(123)->willReturn($fileInfo);
+        $sourceClient->expects($this->once())->method('downloadFile');
 
-        $targetClient->method('bucketExists')->willReturn(true);
-        $targetClient->method('tableExists')->willReturn(false);
-        $targetClient->method('getBucket')->willReturn(['backend' => 'bigquery']);
-        $targetClient->method('uploadFile')->willReturn(456);
-        $targetClient->method('writeTableAsyncDirect');
+        $targetClient->expects($this->once())->method('bucketExists')->with('in.c-test')->willReturn(true);
+        $targetClient->expects($this->once())->method('tableExists')->with($tableInfo['id'])->willReturn(false);
+        $targetClient->expects($this->once())->method('getBucket')
+            ->with('in.c-test')->willReturn(['backend' => 'bigquery']);
+        $targetClient->expects($this->once())->method('uploadFile')->willReturn(456);
+        $targetClient->expects($this->once())->method('writeTableAsyncDirect');
 
         $sourceClient->expects($this->once())
             ->method('exportTableAsync')
@@ -123,15 +125,16 @@ class SapiMigrateTest extends TestCase
         $tableInfo = $this->buildTableInfo('snowflake');
         $fileInfo = $this->buildFileInfo();
 
-        $sourceClient->method('getTable')->willReturn($tableInfo);
-        $sourceClient->method('getFile')->willReturn($fileInfo);
-        $sourceClient->method('downloadFile');
+        $sourceClient->expects($this->once())->method('getTable')->with($tableInfo['id'])->willReturn($tableInfo);
+        $sourceClient->expects($this->once())->method('getFile')->with(123)->willReturn($fileInfo);
+        $sourceClient->expects($this->once())->method('downloadFile');
 
-        $targetClient->method('bucketExists')->willReturn(true);
-        $targetClient->method('tableExists')->willReturn(false);
-        $targetClient->method('getBucket')->willReturn(['backend' => 'snowflake']);
-        $targetClient->method('uploadFile')->willReturn(456);
-        $targetClient->method('writeTableAsyncDirect');
+        $targetClient->expects($this->once())->method('bucketExists')->with('in.c-test')->willReturn(true);
+        $targetClient->expects($this->once())->method('tableExists')->with($tableInfo['id'])->willReturn(false);
+        $targetClient->expects($this->once())->method('getBucket')
+            ->with('in.c-test')->willReturn(['backend' => 'snowflake']);
+        $targetClient->expects($this->once())->method('uploadFile')->willReturn(456);
+        $targetClient->expects($this->once())->method('writeTableAsyncDirect');
 
         $sourceClient->expects($this->once())
             ->method('exportTableAsync')
@@ -153,14 +156,15 @@ class SapiMigrateTest extends TestCase
         $tableInfo = $this->buildTableInfo('bigquery');
         $fileInfo = $this->buildFileInfo();
 
-        $sourceClient->method('getTable')->willReturn($tableInfo);
-        $sourceClient->method('getFile')->willReturn($fileInfo);
-        $sourceClient->method('downloadFile');
+        $sourceClient->expects($this->once())->method('getTable')->with($tableInfo['id'])->willReturn($tableInfo);
+        $sourceClient->expects($this->once())->method('getFile')->with(123)->willReturn($fileInfo);
+        $sourceClient->expects($this->once())->method('downloadFile');
 
-        $targetClient->method('bucketExists')->willReturn(true);
-        $targetClient->method('tableExists')->willReturn(false);
-        $targetClient->method('uploadFile')->willReturn(456);
-        $targetClient->method('writeTableAsyncDirect');
+        $targetClient->expects($this->once())->method('bucketExists')->with('in.c-test')->willReturn(true);
+        $targetClient->expects($this->once())->method('tableExists')->with($tableInfo['id'])->willReturn(false);
+        $targetClient->expects($this->never())->method('getBucket');
+        $targetClient->expects($this->once())->method('uploadFile')->willReturn(456);
+        $targetClient->expects($this->once())->method('writeTableAsyncDirect');
 
         $sourceClient->expects($this->once())
             ->method('exportTableAsync')
@@ -183,19 +187,21 @@ class SapiMigrateTest extends TestCase
         $tableInfo2 = $this->buildTableInfo('snowflake', 'in.c-test.table2');
         $fileInfo = $this->buildFileInfo();
 
-        $sourceClient->method('getTable')->willReturnOnConsecutiveCalls($tableInfo1, $tableInfo2);
-        $sourceClient->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
-        $sourceClient->method('getFile')->willReturn($fileInfo);
-        $sourceClient->method('downloadFile');
+        $sourceClient->expects($this->exactly(2))->method('getTable')
+            ->willReturnOnConsecutiveCalls($tableInfo1, $tableInfo2);
+        $sourceClient->expects($this->exactly(2))->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
+        $sourceClient->expects($this->exactly(2))->method('getFile')->willReturn($fileInfo);
+        $sourceClient->expects($this->exactly(2))->method('downloadFile');
 
-        $targetClient->method('bucketExists')->willReturn(true);
-        $targetClient->method('tableExists')->willReturn(false);
+        $targetClient->expects($this->exactly(2))->method('bucketExists')->willReturn(true);
+        $targetClient->expects($this->exactly(2))->method('tableExists')->willReturn(false);
         // getBucket should be called only once due to caching
         $targetClient->expects($this->once())
             ->method('getBucket')
+            ->with('in.c-test')
             ->willReturn(['backend' => 'bigquery']);
-        $targetClient->method('uploadFile')->willReturn(456);
-        $targetClient->method('writeTableAsyncDirect');
+        $targetClient->expects($this->exactly(2))->method('uploadFile')->willReturn(456);
+        $targetClient->expects($this->exactly(2))->method('writeTableAsyncDirect');
 
         $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
         $migrate->migrate($this->buildConfig(['in.c-test.table1', 'in.c-test.table2']));

--- a/tests/phpunit/SapiMigrateTest.php
+++ b/tests/phpunit/SapiMigrateTest.php
@@ -63,7 +63,6 @@ class SapiMigrateTest extends TestCase
         $fileInfo = $this->buildFileInfo();
 
         $sourceClient->method('getTable')->willReturn($tableInfo);
-        $sourceClient->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
         $sourceClient->method('getFile')->willReturn($fileInfo);
         $sourceClient->method('downloadFile');
 
@@ -79,7 +78,8 @@ class SapiMigrateTest extends TestCase
             ->with(
                 $tableInfo['id'],
                 $this->arrayHasKey('timezone'),
-            );
+            )
+            ->willReturn(['file' => ['id' => 123]]);
 
         $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
         $migrate->migrate($this->buildConfig(['in.c-test.table']));
@@ -94,7 +94,6 @@ class SapiMigrateTest extends TestCase
         $fileInfo = $this->buildFileInfo();
 
         $sourceClient->method('getTable')->willReturn($tableInfo);
-        $sourceClient->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
         $sourceClient->method('getFile')->willReturn($fileInfo);
         $sourceClient->method('downloadFile');
 
@@ -109,7 +108,8 @@ class SapiMigrateTest extends TestCase
             ->with(
                 $tableInfo['id'],
                 $this->callback(fn(array $options) => isset($options['timezone']) && $options['timezone'] === 'UTC'),
-            );
+            )
+            ->willReturn(['file' => ['id' => 123]]);
 
         $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
         $migrate->migrate($this->buildConfig(['in.c-test.table']));
@@ -124,7 +124,6 @@ class SapiMigrateTest extends TestCase
         $fileInfo = $this->buildFileInfo();
 
         $sourceClient->method('getTable')->willReturn($tableInfo);
-        $sourceClient->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
         $sourceClient->method('getFile')->willReturn($fileInfo);
         $sourceClient->method('downloadFile');
 
@@ -139,7 +138,8 @@ class SapiMigrateTest extends TestCase
             ->with(
                 $tableInfo['id'],
                 $this->callback(fn(array $options) => !isset($options['timezone'])),
-            );
+            )
+            ->willReturn(['file' => ['id' => 123]]);
 
         $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
         $migrate->migrate($this->buildConfig(['in.c-test.table']));
@@ -154,7 +154,6 @@ class SapiMigrateTest extends TestCase
         $fileInfo = $this->buildFileInfo();
 
         $sourceClient->method('getTable')->willReturn($tableInfo);
-        $sourceClient->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
         $sourceClient->method('getFile')->willReturn($fileInfo);
         $sourceClient->method('downloadFile');
 
@@ -168,7 +167,8 @@ class SapiMigrateTest extends TestCase
             ->with(
                 $tableInfo['id'],
                 $this->callback(fn(array $options) => !isset($options['timezone'])),
-            );
+            )
+            ->willReturn(['file' => ['id' => 123]]);
 
         $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
         $migrate->migrate($this->buildConfig(['in.c-test.table']));


### PR DESCRIPTION
## Summary

- Upgrades `keboola/storage-api-php-client` to v18.7.0 which introduces a configurable `timezone` option in `exportTableAsync()`
- Passes `timezone=UTC` when exporting from Snowflake **only** when the destination backend is BigQuery (cross-backend migration)
- Adds `keboola/php-datatypes` as an explicit direct dependency (was removed as transitive dep in the client upgrade)
- Caches destination bucket backend per bucket to avoid redundant API calls

## Context

BigQuery stores all datetime values in UTC, but when migrating from Snowflake the timezone is not explicitly set during table export. This causes incorrect datetime handling for `TIMESTAMP_LTZ` columns. The fix is only applied for `sourceBackend=snowflake` AND `destinationBackend=bigquery` — same-backend and other cross-backend migrations are unaffected.

## Test plan

- [x] Unit tests added in `SapiMigrateTest.php` covering all combinations: Snowflake→BigQuery (`timezone=UTC` expected), Snowflake→Snowflake (no timezone), BigQuery source (no timezone), and backend cache reuse across multiple tables
- [x] All existing tests pass (`composer tests-phpunit`)
- [x] `phpcs` and `phpstan` pass