### PR TITLE
[AJDA-2418] feat: fail-fast for NUMBER scale > 9 when migrating Snowflake to BigQuery

### DIFF
--- a/src/StorageModifier.php
+++ b/src/StorageModifier.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Keboola\AppProjectMigrateLargeTables;
 
+use Keboola\Component\UserException;
 use Keboola\Csv\CsvFile;
 use Keboola\Datatype\Definition\BaseType;
 use Keboola\Datatype\Definition\Bigquery;
@@ -68,6 +69,8 @@ class StorageModifier
         $sourceBackend = $tableInfo['bucket']['backend'];
         $destinationBackend = $this->getDestinationBucketBackend($tableInfo['bucket']['id']);
 
+        $this->validateBigqueryNumericScale($sourceBackend, $destinationBackend, $tableInfo);
+
         $columns = [];
         foreach ($tableInfo['definition']['columns'] as $columnDef) {
             $columnName = $columnDef['name'];
@@ -127,6 +130,43 @@ class StorageModifier
                 ));
             }
             throw $e;
+        }
+    }
+
+    private function validateBigqueryNumericScale(
+        string $sourceBackend,
+        string $destinationBackend,
+        array $tableInfo,
+    ): void {
+        if ($sourceBackend !== 'snowflake' || $destinationBackend !== 'bigquery') {
+            return;
+        }
+
+        foreach ($tableInfo['definition']['columns'] as $columnDef) {
+            if (($columnDef['basetype'] ?? null) !== 'NUMERIC') {
+                continue;
+            }
+
+            $length = $columnDef['definition']['length'] ?? null;
+            if ($length === null) {
+                continue;
+            }
+
+            $parts = explode(',', $length);
+            if (count($parts) !== 2) {
+                continue;
+            }
+
+            $scale = (int) trim($parts[1]);
+            if ($scale > 9) {
+                throw new UserException(sprintf(
+                    'Column "%s" has type NUMBER(%s) which exceeds BigQuery\'s maximum scale of 9. '
+                    . 'BigQuery supports NUMERIC with scale up to 9. '
+                    . 'Please adjust the column type before migrating.',
+                    $columnDef['name'],
+                    $length,
+                ));
+            }
         }
     }
 

--- a/src/StorageModifier.php
+++ b/src/StorageModifier.php
@@ -143,7 +143,7 @@ class StorageModifier
         }
 
         foreach ($tableInfo['definition']['columns'] as $columnDef) {
-            if (($columnDef['basetype'] ?? null) !== 'NUMERIC') {
+            if (strtoupper((string) ($columnDef['basetype'] ?? '')) !== 'NUMERIC') {
                 continue;
             }
 

--- a/tests/phpunit/StorageModifierTest.php
+++ b/tests/phpunit/StorageModifierTest.php
@@ -374,7 +374,8 @@ class StorageModifierTest extends TestCase
         $bucketId = 'in.c-test';
 
         $client = $this->createMock(Client::class);
-        $client->method('getBucket')
+        $client->expects($this->once())
+            ->method('getBucket')
             ->with($bucketId)
             ->willReturn(['backend' => 'bigquery']);
 
@@ -399,12 +400,14 @@ class StorageModifierTest extends TestCase
         $bucketId = 'in.c-test';
 
         $client = $this->createMock(Client::class);
-        $client->method('getBucket')
+        $client->expects($this->once())
+            ->method('getBucket')
             ->with($bucketId)
             ->willReturn(['backend' => 'bigquery']);
 
         $client->expects($this->once())
-            ->method('createTableDefinition');
+            ->method('createTableDefinition')
+            ->with($bucketId, $this->anything());
 
         $modifier = new StorageModifier($client);
         $modifier->createTable($this->buildTableInfo(

--- a/tests/phpunit/StorageModifierTest.php
+++ b/tests/phpunit/StorageModifierTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\AppProjectMigrateLargeTables\Tests;
 
 use Keboola\AppProjectMigrateLargeTables\StorageModifier;
+use Keboola\Component\UserException;
 use Keboola\StorageApi\Client;
 use PHPUnit\Framework\TestCase;
 
@@ -366,6 +367,55 @@ class StorageModifierTest extends TestCase
         self::assertNotNull($capturedData);
         self::assertSame(['id'], $capturedData['primaryKeysNames']);
         self::assertSame('my_table', $capturedData['name']);
+    }
+
+    public function testCreateTypedTableSnowflakeToBigqueryThrowsForNumericScaleOver9(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->with($bucketId)
+            ->willReturn(['backend' => 'bigquery']);
+
+        $client->expects($this->never())
+            ->method('createTableDefinition');
+
+        $modifier = new StorageModifier($client);
+
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessageMatches('/Column "amount"/');
+        $this->expectExceptionMessageMatches('/NUMBER\(38,12\)/');
+
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'snowflake',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('amount', 'NUMBER', 'NUMERIC', true, '38,12'),
+            ],
+        ));
+    }
+
+    public function testCreateTypedTableSnowflakeToBigqueryAllowsNumericScaleOf9(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->with($bucketId)
+            ->willReturn(['backend' => 'bigquery']);
+
+        $client->expects($this->once())
+            ->method('createTableDefinition');
+
+        $modifier = new StorageModifier($client);
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'snowflake',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('amount', 'NUMBER', 'NUMERIC', true, '38,9'),
+            ],
+        ));
     }
 
     public function testCreateTypedTableWithUnknownDestinationBackendUsesBasetypeAsType(): void

--- a/tests/phpunit/StorageModifierTest.php
+++ b/tests/phpunit/StorageModifierTest.php
@@ -383,17 +383,19 @@ class StorageModifierTest extends TestCase
 
         $modifier = new StorageModifier($client);
 
-        $this->expectException(UserException::class);
-        $this->expectExceptionMessageMatches('/Column "amount"/');
-        $this->expectExceptionMessageMatches('/NUMBER\(38,12\)/');
-
-        $modifier->createTable($this->buildTableInfo(
-            sourceBackend: 'snowflake',
-            bucketId: $bucketId,
-            columns: [
-                $this->buildColumnDef('amount', 'NUMBER', 'NUMERIC', true, '38,12'),
-            ],
-        ));
+        try {
+            $modifier->createTable($this->buildTableInfo(
+                sourceBackend: 'snowflake',
+                bucketId: $bucketId,
+                columns: [
+                    $this->buildColumnDef('amount', 'NUMBER', 'NUMERIC', true, '38,12'),
+                ],
+            ));
+            $this->fail('Expected UserException was not thrown');
+        } catch (UserException $e) {
+            $this->assertStringContainsString('Column "amount"', $e->getMessage());
+            $this->assertStringContainsString('NUMBER(38,12)', $e->getMessage());
+        }
     }
 
     public function testCreateTypedTableSnowflakeToBigqueryAllowsNumericScaleOf9(): void

--- a/tests/phpunit/StorageModifierTest.php
+++ b/tests/phpunit/StorageModifierTest.php
@@ -383,19 +383,15 @@ class StorageModifierTest extends TestCase
 
         $modifier = new StorageModifier($client);
 
-        try {
-            $modifier->createTable($this->buildTableInfo(
-                sourceBackend: 'snowflake',
-                bucketId: $bucketId,
-                columns: [
-                    $this->buildColumnDef('amount', 'NUMBER', 'NUMERIC', true, '38,12'),
-                ],
-            ));
-            $this->fail('Expected UserException was not thrown');
-        } catch (UserException $e) {
-            $this->assertStringContainsString('Column "amount"', $e->getMessage());
-            $this->assertStringContainsString('NUMBER(38,12)', $e->getMessage());
-        }
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage('Column "amount" has type NUMBER(38,12)');
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'snowflake',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('amount', 'NUMBER', 'NUMERIC', true, '38,12'),
+            ],
+        ));
     }
 
     public function testCreateTypedTableSnowflakeToBigqueryAllowsNumericScaleOf9(): void


### PR DESCRIPTION
## Summary

- BigQuery supports NUMERIC with maximum scale 9; Snowflake allows `NUMBER(38, 12)` and higher
- Table creation succeeds but data import fails silently — bad UX for users
- Added `validateBigqueryNumericScale()` in `StorageModifier::createTypedTable()` that throws `UserException` with a descriptive message before any table is created

## Test plan

- [x] Unit test: `testCreateTypedTableSnowflakeToBigqueryThrowsForNumericScaleOver9` — verifies `UserException` is thrown for `NUMBER(38,12)`, `createTableDefinition` is never called
- [x] Unit test: `testCreateTypedTableSnowflakeToBigqueryAllowsNumericScaleOf9` — verifies scale=9 (boundary) passes without exception
- [x] All 27 existing unit tests pass
- [x] `phpcs` and `phpstan` clean

Linear: https://linear.app/keboola/issue/AJDA-2418