### PR TITLE
[AJDA-2417] Add forcePrimaryKeyNotNull parameter for typed table migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The `config.json` configuration file contains the following properties:
     - `gcsLargeTable` - object (optional): Configuration for parallel GCS large table migration
         - `parallelChunks` - integer (optional, default `3`, min `1`, max `20`): Number of chunks to migrate in parallel
         - `chunkSize` - integer (optional, default `150`, min `1`): Number of slice files per chunk
+    - `forcePrimaryKeyNotNull` - boolean (optional): If set to `true`, primary key columns will always be created as `NOT NULL` during typed table migration. Useful when source primary key columns are marked nullable but the target backend (e.g. BigQuery) requires primary keys to be non-nullable. Default: `false`.
     - `db` - object (optional in `database` mode; extends the `db` object in `image_parameters`):
         - `host` - string (required): Snowflake host
         - `username` - string (required): Snowflake username

--- a/src/Config.php
+++ b/src/Config.php
@@ -249,6 +249,11 @@ class Config extends BaseConfig
         return (bool) $this->getValue(['parameters', 'migrateData'], true);
     }
 
+    public function forcePrimaryKeyNotNull(): bool
+    {
+        return (bool) $this->getValue(['parameters', 'forcePrimaryKeyNotNull']);
+    }
+
     public function getGcsLargeTableParallelChunks(): int
     {
         return $this->getIntValue(['parameters', 'gcsLargeTable', 'parallelChunks'], 3);

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -27,6 +27,7 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->booleanNode('preserveTimestamp')->defaultFalse()->end()
                 ->arrayNode('tables')->prototype('scalar')->end()->end()
                 ->booleanNode('migrateData')->defaultTrue()->end()
+                ->booleanNode('forcePrimaryKeyNotNull')->defaultFalse()->end()
                 ->arrayNode('gcsLargeTable')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/src/StorageModifier.php
+++ b/src/StorageModifier.php
@@ -37,10 +37,10 @@ class StorageModifier
         $this->client->createBucket($bucketName, $bucketStage);
     }
 
-    public function createTable(array $tableInfo): void
+    public function createTable(array $tableInfo, bool $forcePrimaryKeyNotNull = false): void
     {
         if ($tableInfo['isTyped']) {
-            $this->createTypedTable($tableInfo);
+            $this->createTypedTable($tableInfo, $forcePrimaryKeyNotNull);
         } else {
             $this->createNonTypedTable($tableInfo);
         }
@@ -64,7 +64,7 @@ class StorageModifier
         );
     }
 
-    private function createTypedTable(array $tableInfo): void
+    private function createTypedTable(array $tableInfo, bool $forcePrimaryKeyNotNull = false): void
     {
         $sourceBackend = $tableInfo['bucket']['backend'];
         $destinationBackend = $this->getDestinationBucketBackend($tableInfo['bucket']['id']);
@@ -90,6 +90,11 @@ class StorageModifier
                 if (isset($columnDef['definition']['default'])) {
                     $definition['default'] = $columnDef['definition']['default'];
                 }
+            }
+
+            $isPrimaryKey = in_array($columnName, $tableInfo['primaryKey'], true);
+            if ($forcePrimaryKeyNotNull && $isPrimaryKey) {
+                $definition['nullable'] = false;
             }
 
             $columns[] = [

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -85,7 +85,7 @@ class SapiMigrate implements MigrateInterface
                     $this->logger->info(sprintf('[dry-run] Creating table %s', $tableInfo['id']));
                 } else {
                     $this->logger->info(sprintf('Creating table %s', $tableInfo['id']));
-                    $this->storageModifier->createTable($tableInfo);
+                    $this->storageModifier->createTable($tableInfo, $config->forcePrimaryKeyNotNull());
                 }
             }
 

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -95,4 +95,23 @@ class ConfigTest extends TestCase
             ],
         ]);
     }
+
+    public function testForcePrimaryKeyNotNullDefaultIsFalse(): void
+    {
+        $config = $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+        ]);
+        $this->assertFalse($config->forcePrimaryKeyNotNull());
+    }
+
+    public function testForcePrimaryKeyNotNullCanBeEnabled(): void
+    {
+        $config = $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+            'forcePrimaryKeyNotNull' => true,
+        ]);
+        $this->assertTrue($config->forcePrimaryKeyNotNull());
+    }
 }

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -102,7 +102,7 @@ class ConfigTest extends TestCase
             'sourceKbcUrl' => 'https://connection.keboola.com',
             '#sourceKbcToken' => 'token',
         ]);
-        $this->assertFalse($config->forcePrimaryKeyNotNull());
+        self::assertFalse($config->forcePrimaryKeyNotNull());
     }
 
     public function testForcePrimaryKeyNotNullCanBeEnabled(): void
@@ -112,6 +112,6 @@ class ConfigTest extends TestCase
             '#sourceKbcToken' => 'token',
             'forcePrimaryKeyNotNull' => true,
         ]);
-        $this->assertTrue($config->forcePrimaryKeyNotNull());
+        self::assertTrue($config->forcePrimaryKeyNotNull());
     }
 }

--- a/tests/phpunit/SapiMigrateTest.php
+++ b/tests/phpunit/SapiMigrateTest.php
@@ -13,7 +13,7 @@ use Psr\Log\NullLogger;
 
 class SapiMigrateTest extends TestCase
 {
-    private function buildConfig(array $migrateTables = []): Config
+    private function buildConfig(array $migrateTables = [], bool $forcePrimaryKeyNotNull = false): Config
     {
         $params = [
             'sourceKbcUrl' => 'https://connection.keboola.com',
@@ -21,6 +21,9 @@ class SapiMigrateTest extends TestCase
         ];
         if ($migrateTables !== []) {
             $params['tables'] = $migrateTables;
+        }
+        if ($forcePrimaryKeyNotNull) {
+            $params['forcePrimaryKeyNotNull'] = true;
         }
 
         return new Config(['parameters' => $params], new ConfigDefinition());
@@ -176,6 +179,55 @@ class SapiMigrateTest extends TestCase
 
         $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
         $migrate->migrate($this->buildConfig(['in.c-test.table']));
+    }
+
+    public function testForcePrimaryKeyNotNullIsPassedToTableCreation(): void
+    {
+        $sourceClient = $this->createMock(Client::class);
+        $targetClient = $this->createMock(Client::class);
+
+        $tableInfo = array_merge($this->buildTableInfo('snowflake'), [
+            'isTyped' => true,
+            'primaryKey' => ['id'],
+            'definition' => [
+                'columns' => [
+                    ['name' => 'id', 'basetype' => 'INTEGER', 'definition' => [
+                        'type' => 'INTEGER', 'nullable' => true,
+                    ]],
+                    ['name' => 'name', 'basetype' => 'STRING', 'definition' => [
+                        'type' => 'VARCHAR', 'nullable' => true,
+                    ]],
+                ],
+            ],
+            'metadata' => [],
+            'columnMetadata' => [],
+        ]);
+        $fileInfo = $this->buildFileInfo();
+
+        $sourceClient->method('getTable')->willReturn($tableInfo);
+        $sourceClient->method('getFile')->willReturn($fileInfo);
+        $sourceClient->method('downloadFile');
+        $sourceClient->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
+
+        $targetClient->method('bucketExists')->willReturn(true);
+        $targetClient->method('tableExists')->willReturn(false);
+        $targetClient->method('getBucket')->willReturn(['backend' => 'snowflake']);
+        $targetClient->method('uploadFile')->willReturn(456);
+        $targetClient->method('writeTableAsyncDirect');
+
+        $capturedData = null;
+        $targetClient->expects($this->once())
+            ->method('createTableDefinition')
+            ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
+                $capturedData = $data;
+            });
+
+        $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
+        $migrate->migrate($this->buildConfig(['in.c-test.table'], forcePrimaryKeyNotNull: true));
+
+        self::assertNotNull($capturedData);
+        self::assertFalse($capturedData['columns'][0]['definition']['nullable'], 'PK column must be not nullable');
+        self::assertTrue($capturedData['columns'][1]['definition']['nullable'], 'Non-PK column must stay nullable');
     }
 
     public function testDestinationBucketBackendIsCachedAcrossMultipleTables(): void

--- a/tests/phpunit/SapiMigrateTest.php
+++ b/tests/phpunit/SapiMigrateTest.php
@@ -204,23 +204,26 @@ class SapiMigrateTest extends TestCase
         ]);
         $fileInfo = $this->buildFileInfo();
 
-        $sourceClient->method('getTable')->willReturn($tableInfo);
-        $sourceClient->method('getFile')->willReturn($fileInfo);
-        $sourceClient->method('downloadFile');
-        $sourceClient->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
+        $sourceClient->expects($this->once())->method('getTable')->with('in.c-test.table')->willReturn($tableInfo);
+        $sourceClient->expects($this->once())->method('getFile')->with(123)->willReturn($fileInfo);
+        $sourceClient->expects($this->once())->method('downloadFile');
+        $sourceClient->expects($this->once())->method('exportTableAsync')->willReturn(['file' => ['id' => 123]]);
 
-        $targetClient->method('bucketExists')->willReturn(true);
-        $targetClient->method('tableExists')->willReturn(false);
-        $targetClient->method('getBucket')->willReturn(['backend' => 'snowflake']);
-        $targetClient->method('uploadFile')->willReturn(456);
-        $targetClient->method('writeTableAsyncDirect');
+        $targetClient->expects($this->once())->method('bucketExists')->with('in.c-test')->willReturn(true);
+        $targetClient->expects($this->once())->method('tableExists')->with('in.c-test.table')->willReturn(false);
+        // getBucket is called twice: once from SapiMigrate::getDestinationBucketBackend, once from StorageModifier
+        $targetClient->expects($this->exactly(2))->method('getBucket')
+            ->with('in.c-test')->willReturn(['backend' => 'snowflake']);
+        $targetClient->expects($this->once())->method('uploadFile')->willReturn(456);
+        $targetClient->expects($this->once())->method('writeTableAsyncDirect');
 
         $capturedData = null;
         $targetClient->expects($this->once())
             ->method('createTableDefinition')
-            ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
+            ->with('in.c-test', $this->callback(function (array $data) use (&$capturedData) {
                 $capturedData = $data;
-            });
+                return true;
+            }));
 
         $migrate = new SapiMigrate($sourceClient, $targetClient, new NullLogger());
         $migrate->migrate($this->buildConfig(['in.c-test.table'], forcePrimaryKeyNotNull: true));

--- a/tests/phpunit/StorageModifierTest.php
+++ b/tests/phpunit/StorageModifierTest.php
@@ -468,6 +468,70 @@ class StorageModifierTest extends TestCase
         ));
     }
 
+    public function testForcePrimaryKeyNotNullOverridesNullableForPkColumns(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->willReturn(['backend' => 'snowflake']);
+
+        $capturedData = null;
+        $client->method('createTableDefinition')
+            ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
+                $capturedData = $data;
+            });
+
+        $modifier = new StorageModifier($client);
+        $modifier->createTable(
+            $this->buildTableInfo(
+                sourceBackend: 'snowflake',
+                bucketId: $bucketId,
+                columns: [
+                    $this->buildColumnDef('id', 'INTEGER', 'INTEGER', true),
+                    $this->buildColumnDef('name', 'VARCHAR', 'STRING', true),
+                ],
+                primaryKey: ['id'],
+            ),
+            forcePrimaryKeyNotNull: true,
+        );
+
+        $this->assertNotNull($capturedData);
+        $this->assertFalse($capturedData['columns'][0]['definition']['nullable'], 'PK column must be not nullable');
+        $this->assertTrue($capturedData['columns'][1]['definition']['nullable'], 'Non-PK column must stay nullable');
+    }
+
+    public function testForcePrimaryKeyNotNullFalsePreservesNullable(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->willReturn(['backend' => 'snowflake']);
+
+        $capturedData = null;
+        $client->method('createTableDefinition')
+            ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
+                $capturedData = $data;
+            });
+
+        $modifier = new StorageModifier($client);
+        $modifier->createTable(
+            $this->buildTableInfo(
+                sourceBackend: 'snowflake',
+                bucketId: $bucketId,
+                columns: [
+                    $this->buildColumnDef('id', 'INTEGER', 'INTEGER', true),
+                ],
+                primaryKey: ['id'],
+            ),
+            forcePrimaryKeyNotNull: false,
+        );
+
+        $this->assertNotNull($capturedData);
+        $this->assertTrue($capturedData['columns'][0]['definition']['nullable'], 'Without flag, nullable stays true');
+    }
+
     public function testCreateTypedTableWithUnknownDestinationBackendUsesBasetypeAsType(): void
     {
         $bucketId = 'in.c-test';

--- a/tests/phpunit/StorageModifierTest.php
+++ b/tests/phpunit/StorageModifierTest.php
@@ -473,11 +473,13 @@ class StorageModifierTest extends TestCase
         $bucketId = 'in.c-test';
 
         $client = $this->createMock(Client::class);
-        $client->method('getBucket')
+        $client->expects($this->once())
+            ->method('getBucket')
             ->willReturn(['backend' => 'snowflake']);
 
         $capturedData = null;
-        $client->method('createTableDefinition')
+        $client->expects($this->once())
+            ->method('createTableDefinition')
             ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
                 $capturedData = $data;
             });
@@ -496,9 +498,9 @@ class StorageModifierTest extends TestCase
             forcePrimaryKeyNotNull: true,
         );
 
-        $this->assertNotNull($capturedData);
-        $this->assertFalse($capturedData['columns'][0]['definition']['nullable'], 'PK column must be not nullable');
-        $this->assertTrue($capturedData['columns'][1]['definition']['nullable'], 'Non-PK column must stay nullable');
+        self::assertNotNull($capturedData);
+        self::assertFalse($capturedData['columns'][0]['definition']['nullable'], 'PK column must be not nullable');
+        self::assertTrue($capturedData['columns'][1]['definition']['nullable'], 'Non-PK column must stay nullable');
     }
 
     public function testForcePrimaryKeyNotNullFalsePreservesNullable(): void
@@ -506,11 +508,13 @@ class StorageModifierTest extends TestCase
         $bucketId = 'in.c-test';
 
         $client = $this->createMock(Client::class);
-        $client->method('getBucket')
+        $client->expects($this->once())
+            ->method('getBucket')
             ->willReturn(['backend' => 'snowflake']);
 
         $capturedData = null;
-        $client->method('createTableDefinition')
+        $client->expects($this->once())
+            ->method('createTableDefinition')
             ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
                 $capturedData = $data;
             });
@@ -528,8 +532,8 @@ class StorageModifierTest extends TestCase
             forcePrimaryKeyNotNull: false,
         );
 
-        $this->assertNotNull($capturedData);
-        $this->assertTrue($capturedData['columns'][0]['definition']['nullable'], 'Without flag, nullable stays true');
+        self::assertNotNull($capturedData);
+        self::assertTrue($capturedData['columns'][0]['definition']['nullable'], 'Without flag, nullable stays true');
     }
 
     public function testCreateTypedTableWithUnknownDestinationBackendUsesBasetypeAsType(): void

--- a/tests/phpunit/StorageModifierTest.php
+++ b/tests/phpunit/StorageModifierTest.php
@@ -386,6 +386,7 @@ class StorageModifierTest extends TestCase
 
         $this->expectException(UserException::class);
         $this->expectExceptionMessage('Column "amount" has type NUMBER(38,12)');
+
         $modifier->createTable($this->buildTableInfo(
             sourceBackend: 'snowflake',
             bucketId: $bucketId,
@@ -419,55 +420,6 @@ class StorageModifierTest extends TestCase
         ));
     }
 
-    public function testCreateTypedTableSnowflakeToBigqueryThrowsForNumericScaleOver9(): void
-    {
-        $bucketId = 'in.c-test';
-
-        $client = $this->createMock(Client::class);
-        $client->method('getBucket')
-            ->with($bucketId)
-            ->willReturn(['backend' => 'bigquery']);
-
-        $client->expects($this->never())
-            ->method('createTableDefinition');
-
-        $modifier = new StorageModifier($client);
-
-        $this->expectException(UserException::class);
-        $this->expectExceptionMessageMatches('/Column "amount"/');
-        $this->expectExceptionMessageMatches('/NUMBER\(38,12\)/');
-
-        $modifier->createTable($this->buildTableInfo(
-            sourceBackend: 'snowflake',
-            bucketId: $bucketId,
-            columns: [
-                $this->buildColumnDef('amount', 'NUMBER', 'NUMERIC', true, '38,12'),
-            ],
-        ));
-    }
-
-    public function testCreateTypedTableSnowflakeToBigqueryAllowsNumericScaleOf9(): void
-    {
-        $bucketId = 'in.c-test';
-
-        $client = $this->createMock(Client::class);
-        $client->method('getBucket')
-            ->with($bucketId)
-            ->willReturn(['backend' => 'bigquery']);
-
-        $client->expects($this->once())
-            ->method('createTableDefinition');
-
-        $modifier = new StorageModifier($client);
-        $modifier->createTable($this->buildTableInfo(
-            sourceBackend: 'snowflake',
-            bucketId: $bucketId,
-            columns: [
-                $this->buildColumnDef('amount', 'NUMBER', 'NUMERIC', true, '38,9'),
-            ],
-        ));
-    }
-
     public function testForcePrimaryKeyNotNullOverridesNullableForPkColumns(): void
     {
         $bucketId = 'in.c-test';
@@ -475,14 +427,16 @@ class StorageModifierTest extends TestCase
         $client = $this->createMock(Client::class);
         $client->expects($this->once())
             ->method('getBucket')
+            ->with($bucketId)
             ->willReturn(['backend' => 'snowflake']);
 
         $capturedData = null;
         $client->expects($this->once())
             ->method('createTableDefinition')
-            ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
+            ->with($bucketId, $this->callback(function (array $data) use (&$capturedData) {
                 $capturedData = $data;
-            });
+                return true;
+            }));
 
         $modifier = new StorageModifier($client);
         $modifier->createTable(
@@ -510,14 +464,16 @@ class StorageModifierTest extends TestCase
         $client = $this->createMock(Client::class);
         $client->expects($this->once())
             ->method('getBucket')
+            ->with($bucketId)
             ->willReturn(['backend' => 'snowflake']);
 
         $capturedData = null;
         $client->expects($this->once())
             ->method('createTableDefinition')
-            ->willReturnCallback(function (string $id, array $data) use (&$capturedData): void {
+            ->with($bucketId, $this->callback(function (array $data) use (&$capturedData) {
                 $capturedData = $data;
-            });
+                return true;
+            }));
 
         $modifier = new StorageModifier($client);
         $modifier->createTable(

--- a/tests/phpunit/StorageModifierTest.php
+++ b/tests/phpunit/StorageModifierTest.php
@@ -419,6 +419,55 @@ class StorageModifierTest extends TestCase
         ));
     }
 
+    public function testCreateTypedTableSnowflakeToBigqueryThrowsForNumericScaleOver9(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->with($bucketId)
+            ->willReturn(['backend' => 'bigquery']);
+
+        $client->expects($this->never())
+            ->method('createTableDefinition');
+
+        $modifier = new StorageModifier($client);
+
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessageMatches('/Column "amount"/');
+        $this->expectExceptionMessageMatches('/NUMBER\(38,12\)/');
+
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'snowflake',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('amount', 'NUMBER', 'NUMERIC', true, '38,12'),
+            ],
+        ));
+    }
+
+    public function testCreateTypedTableSnowflakeToBigqueryAllowsNumericScaleOf9(): void
+    {
+        $bucketId = 'in.c-test';
+
+        $client = $this->createMock(Client::class);
+        $client->method('getBucket')
+            ->with($bucketId)
+            ->willReturn(['backend' => 'bigquery']);
+
+        $client->expects($this->once())
+            ->method('createTableDefinition');
+
+        $modifier = new StorageModifier($client);
+        $modifier->createTable($this->buildTableInfo(
+            sourceBackend: 'snowflake',
+            bucketId: $bucketId,
+            columns: [
+                $this->buildColumnDef('amount', 'NUMBER', 'NUMERIC', true, '38,9'),
+            ],
+        ));
+    }
+
     public function testCreateTypedTableWithUnknownDestinationBackendUsesBasetypeAsType(): void
     {
         $bucketId = 'in.c-test';


### PR DESCRIPTION
## Summary
- Adds new config parameter `forcePrimaryKeyNotNull` (default: `false`)
- When enabled, overrides `nullable` to `false` for all primary key columns when creating typed tables
- Prevents HTTP 400 errors from BigQuery: _"Primary keys columns must be set nullable false"_
- Applies only to typed tables (`createTypedTable`); non-typed tables are unaffected
- Works for both same-backend and cross-backend migrations

## Test plan
- [x] `testForcePrimaryKeyNotNullDefaultIsFalse` — výchozí hodnota je `false`
- [x] `testForcePrimaryKeyNotNullCanBeEnabled` — lze nastavit na `true`
- [x] `testForcePrimaryKeyNotNullOverridesNullableForPkColumns` — PK sloupec s `nullable: true` → přepsán na `false`, non-PK zachován
- [x] `testForcePrimaryKeyNotNullFalsePreservesNullable` — bez flagu `nullable` zůstane