### PR TITLE
[AJDA-2577] Add architectural documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,98 @@
+# app-project-migrate-tables-data – AI Development Context
+
+## What this repository does
+
+Keboola App component for direct table data migration between projects. Run by `app-project-migrate` as Phase 5 of the pipeline. Component ID: `keboola.app-project-migrate-large-tables`.
+
+Has two modes: `sapi` (via Storage API) and `database` (via Snowflake replication).
+
+## Documentation
+
+- **`docs/overview.md`** – sapi mode, database mode, GCS large tables, stack mappings
+- **`docs/how-it-works.md`** – step-by-step migration flow (SAPI, parallel GCS workers, database replication)
+- **`docs/configuration.md`** – complete input parameter reference for both modes
+
+## Required environment variables
+
+Before running tests, verify that these variables are present in `.env` (or exported in the shell). If missing, ask for them explicitly.
+
+**Required to run tests:**
+
+| Variable | Description |
+|---|---|
+| `SOURCE_CLIENT_URL` | URL of the source Keboola project |
+| `SOURCE_CLIENT_TOKEN` | Storage token of the source project |
+| `DESTINATION_CLIENT_URL` | URL of the destination Keboola project |
+| `DESTINATION_CLIENT_TOKEN` | Storage token of the destination project |
+
+**Only for local application run (not for tests):**
+
+| Variable | Description |
+|---|---|
+| `KBC_URL` | Destination project URL (injected by Keboola platform) |
+| `KBC_TOKEN` | Destination project token (injected by Keboola platform) |
+
+> Tests use `SOURCE_CLIENT_*` and `DESTINATION_CLIENT_*`. `KBC_*` variables are only for running the application locally. Check that the `.env` file exists in the repo root.
+
+## Development commands
+
+Service name in `docker-compose.yml` is `dev`.
+
+```bash
+docker compose run --rm dev composer phpcs
+docker compose run --rm dev composer phpstan
+docker compose run --rm dev composer tests           # tests-phpunit + tests-datadir
+docker compose run --rm dev composer tests-phpunit   # unit tests
+docker compose run --rm dev composer tests-datadir   # functional tests
+docker compose run --rm dev composer build           # phplint + phpcs + phpstan + tests
+```
+
+## Key files
+
+| File | Purpose |
+|---|---|
+| `src/Component.php` | Entry point, mode routing + `createReplications` sync action registration |
+| `src/Config.php` | Getters + predefined stack-to-Snowflake-DB mappings |
+| `src/Configuration/ConfigDefinition.php` | Parameter validation for `run` action |
+| `src/Configuration/CreateReplicationsConfigDefinition.php` | Parameter validation for `createReplications` sync action |
+| `src/MigrateInterface.php` | Interface for strategy pattern (SapiMigrate, DatabaseMigrate) |
+| `src/Strategy/SapiMigrate.php` | SAPI transfer logic |
+| `src/Strategy/SapiMigrate/MigrateGcsLargeTable.php` | Parallel worker migration of large GCS tables |
+| `src/Strategy/DatabaseMigrate.php` | Snowflake replication logic |
+| `src/Strategy/DatabaseReplication.php` | Sync action for enabling replication |
+| `src/Snowflake/Connection.php` | Snowflake DB connection wrapper (grants, role handling) |
+| `src/StorageModifier.php` | Creates buckets and tables in destination project (incl. cross-backend type mapping) |
+| `src/worker-chunk.php` | Child process: downloads GCS chunk, uploads to SAPI |
+
+## GCS large tables (>50 GB, sliced, GCP stack)
+
+Parallel worker approach – manifest is split into chunks, each worker (`worker-chunk.php`) processes one chunk. Parameters: `gcsLargeTable.parallelChunks` (default 3, max 20), `gcsLargeTable.chunkSize` (default 150).
+
+PK is removed before chunked import and restored after completion.
+
+## Predefined stack mappings (src/Config.php)
+
+Used in database mode:
+
+| Stack | Snowflake account | Region |
+|---|---|---|
+| connection.keboola.com | KEBOOLA | AWS_US_WEST_2 |
+| connection.eu-central-1.keboola.com | KEBOOLA | AWS_EU_CENTRAL_1 |
+| connection.north-europe.azure.keboola.com | KEBOOLA | AZURE_WESTEUROPE |
+| connection.europe-west3.gcp.keboola.com | IK34405 | GCP_EUROPE_WEST4 |
+| connection.us-east4.gcp.keboola.com | NE35810 | GCP_US_EAST4 |
+| connection.coates.keboola.cloud | KEBOOLA | AWS_US_EAST_1 |
+
+## Cross-backend type mapping
+
+When migrating Snowflake → BigQuery, `StorageModifier` maps column types. BigQuery NUMERIC max scale = 9.
+
+## Coding standards
+
+- PHP 8.x with strict types
+- PHPStan level max
+- Keboola coding standard (PSR-12)
+
+## Related repositories
+
+- Orchestrator: `app-project-migrate`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,161 @@
+# Configuration parameter reference – app-project-migrate-tables-data
+
+## Required parameters
+
+| Parameter | Description |
+|---|---|
+| `sourceKbcUrl` | URL of the source Keboola project |
+| `#sourceKbcToken` | Storage token of the source project |
+
+## General parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `mode` | `sapi` | Migration mode: `sapi` (via Storage API) or `database` (via Snowflake replication) |
+| `dryRun` | `false` | Simulation without actual changes |
+| `preserveTimestamp` | `false` | Preserves `_timestamp` column values from source data |
+| `forcePrimaryKeyNotNull` | `false` | Forces NOT NULL on PK columns in typed tables |
+| `tables` | `[]` | Whitelist of table IDs to migrate – if empty, all tables are migrated |
+| `migrateData` | `true` | In database mode: performs TRUNCATE + INSERT from replica to destination. Can be disabled for preparation phase (only CREATE REPLICA + REFRESH, no data transfer). |
+
+## SAPI mode – specific parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `gcsLargeTable.parallelChunks` | `3` | Number of parallel worker processes for large GCS tables (min 1, max 20) |
+| `gcsLargeTable.chunkSize` | `150` | Number of GCS slices per worker chunk (min 1) |
+
+> Large GCS table = sliced file larger than 50 GB on GCP storage backend.
+
+## Database mode – specific parameters
+
+Required if `mode: database`. Forbidden if `mode: sapi`.
+
+### Snowflake credentials
+
+| Parameter | Required | Description |
+|---|---|---|
+| `db.host` | ✓ | Snowflake host (e.g. `xy12345.snowflakecomputing.com`) |
+| `db.username` | ✓ | Snowflake username |
+| `db.#password` | one of | Password |
+| `db.#privateKey` | one of | Private key for key-pair authentication |
+| `db.warehouse` | ✓ | Snowflake warehouse name |
+| `db.warehouse_size` | `SMALL` | Warehouse size: `SMALL`, `MEDIUM`, or `LARGE` |
+
+### BYODB parameters
+
+| Parameter | Default | Description |
+|---|---|---|
+| `isSourceByodb` | `false` | Source uses a non-standard Snowflake account (BYODB) |
+| `sourceByodb` | – | BYODB database name (required if `isSourceByodb: true`) |
+| `includeWorkspaceSchemas` | `[]` | Workspace schemas to include in database migration |
+
+### Replication switches
+
+| Parameter | Default | Description |
+|---|---|---|
+| `replica.create` | `true` | Creates replica database |
+| `replica.refresh` | `true` | Refreshes replica before migration |
+| `replica.drop` | `true` | Drops replica database after migration |
+
+> The TRUNCATE + INSERT from replica to destination is controlled by the `migrateData` parameter (see General parameters) – it is at the `parameters` level, not under `replica`.
+
+> Predefined stack-to-Snowflake-account mappings are in `src/Config.php`. To add a new stack, extend this mapping.
+
+## Configuration examples
+
+### SAPI mode (default)
+
+```json
+{
+  "parameters": {
+    "mode": "sapi",
+    "sourceKbcUrl": "https://connection.keboola.com",
+    "#sourceKbcToken": "xxx"
+  }
+}
+```
+
+### SAPI mode with increased parallelism for large GCS tables
+
+```json
+{
+  "parameters": {
+    "mode": "sapi",
+    "sourceKbcUrl": "https://connection.europe-west3.gcp.keboola.com",
+    "#sourceKbcToken": "xxx",
+    "gcsLargeTable": {
+      "parallelChunks": 10,
+      "chunkSize": 200
+    }
+  }
+}
+```
+
+### SAPI mode – selected tables only
+
+```json
+{
+  "parameters": {
+    "mode": "sapi",
+    "sourceKbcUrl": "https://connection.keboola.com",
+    "#sourceKbcToken": "xxx",
+    "tables": [
+      "in.c-my-bucket.my-table",
+      "in.c-my-bucket.another-table"
+    ]
+  }
+}
+```
+
+### Database mode (Snowflake replication)
+
+```json
+{
+  "parameters": {
+    "mode": "database",
+    "sourceKbcUrl": "https://connection.keboola.com",
+    "#sourceKbcToken": "xxx",
+    "db": {
+      "host": "keboola.snowflakecomputing.com",
+      "username": "svc_migrate",
+      "#password": "secret",
+      "warehouse": "MIGRATE_WH",
+      "warehouse_size": "MEDIUM"
+    }
+  }
+}
+```
+
+### Database mode with BYODB source
+
+```json
+{
+  "parameters": {
+    "mode": "database",
+    "sourceKbcUrl": "https://connection.keboola.com",
+    "#sourceKbcToken": "xxx",
+    "isSourceByodb": true,
+    "sourceByodb": "CUSTOMER_DB_NAME",
+    "db": {
+      "host": "keboola.snowflakecomputing.com",
+      "username": "svc_migrate",
+      "#password": "secret",
+      "warehouse": "MIGRATE_WH"
+    }
+  }
+}
+```
+
+### Dry run (simulation)
+
+```json
+{
+  "parameters": {
+    "mode": "sapi",
+    "sourceKbcUrl": "https://connection.keboola.com",
+    "#sourceKbcToken": "xxx",
+    "dryRun": true
+  }
+}
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,7 +29,7 @@
 
 ## Database mode – specific parameters
 
-Required if `mode: database`. Forbidden if `mode: sapi`.
+Required if `mode: database`. Ignored if `mode: sapi`.
 
 ### Snowflake credentials
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -4,7 +4,7 @@
 
 ```
 Component::run()
-  ├─ config.getDataMode() === 'database'  → DatabaseMigrate::migrate()
+  ├─ config.getMode() === 'database'      → DatabaseMigrate::migrate()
   └─ otherwise                            → SapiMigrate::migrate()
 ```
 
@@ -32,7 +32,7 @@ foreach tables (from configuration or getAllTables()):
 
 ### getAllTables() – table selection
 
-If no whitelist (`migrateTables`) is defined, iterates through all source project buckets:
+If no whitelist (`tables`) is defined, iterates through all source project buckets:
 - Compares tables in source and destination projects
 - Skips tables that already exist in destination and have `rowsCount > 0`
 - Result is prepended to the array (newest bucket first)
@@ -181,7 +181,7 @@ skips schemas:
   - INFORMATION_SCHEMA
   - PUBLIC
   - READER_* (reader schemas)
-  - WORKSPACE_* (unless in includedWorkspaceSchemas)
+  - WORKSPACE_* (unless in includeWorkspaceSchemas)
 
 forEach schema:
   if bucket does not exist in SAPI: createBucket()
@@ -217,11 +217,11 @@ INSERT INTO <targetDb>.<schema>.<table> (<cols>)
 | `INFORMATION_SCHEMA` | Snowflake system schema |
 | `PUBLIC` | Default empty schema |
 | `READER_*` | Reader schemas for data sharing (Data Sharing) |
-| `WORKSPACE_*` and `<number>_WORKSPACE*` | Workspaces (regex `^(\d+_)?WORKSPACE`) – included only if explicitly in `includedWorkspaceSchemas` |
+| `WORKSPACE_*` and `<number>_WORKSPACE*` | Workspaces (regex `^(\d+_)?WORKSPACE`) – included only if explicitly in `includeWorkspaceSchemas` |
 
 ### Predefined stack mappings
 
-For standard Keboola stacks, the source Snowflake account and region are predefined in `Config.php` (constant `STACK_URL_TO_SNOWFLAKE_DATABASE`). For other stacks or BYODB, set manually:
+For standard Keboola stacks, the source Snowflake account and region are predefined in `Config.php` (constants `Config::STACK_DATABASES` and `Config::BYODB_DATABASES`). For other stacks or BYODB, set manually:
 
 ```
 isSourceByodb: true

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,252 @@
+# app-project-migrate-tables-data – how data migration works
+
+## Entry point: Component.php
+
+```
+Component::run()
+  ├─ config.getDataMode() === 'database'  → DatabaseMigrate::migrate()
+  └─ otherwise                            → SapiMigrate::migrate()
+```
+
+---
+
+## SAPI mode
+
+### SapiMigrate::migrate() flow
+
+```
+foreach tables (from configuration or getAllTables()):
+  getTable($tableId)  →  tableInfo from source project
+
+  skips: stage === 'sys'
+  skips: isAlias === true
+
+  if bucket does not exist in destination:
+    storageModifier->createBucket()
+
+  if table does not exist in destination:
+    storageModifier->createTable(tableInfo)
+
+  migrateTable(tableInfo, config)
+```
+
+### getAllTables() – table selection
+
+If no whitelist (`migrateTables`) is defined, iterates through all source project buckets:
+- Compares tables in source and destination projects
+- Skips tables that already exist in destination and have `rowsCount > 0`
+- Result is prepended to the array (newest bucket first)
+
+### migrateTable() – standard flow
+
+```
+exportTableAsync(tableId, gzip: true, includeInternalTimestamp)
+  → fileId
+
+getFile(fileId)  →  fileInfo
+
+if provider === 'gcp' AND isSliced AND sizeBytes > 50 GB:
+  migrateGcsLargeTable->migrate()  ← see below
+
+if isSliced:
+  downloadSlicedFile(fileId, tmpFolder)  →  slices
+  uploadSlicedFile(slices, federationToken)  →  destinationFileId
+
+if non-sliced:
+  downloadFile(fileId, fileName)
+  uploadFile(fileName, federationToken)   →  destinationFileId
+
+writeTableAsyncDirect(tableId, {dataFileId, columns, useTimestampFromDataFile})
+```
+
+### GCS large tables – parallel worker migration
+
+Activation condition: source file is on GCS (`provider === 'gcp'`), is sliced and larger than **50 GB**.
+
+```
+MigrateGcsLargeTable::migrate(fileId, tableInfo, preserveTimestamp):
+
+1. getFile(fileId, federationToken=true)
+   → fileInfo with gcsPath (bucket + key) and gcsCredentials
+
+2. GcsClient::bucket->object(manifest)->downloadAsString()
+   → manifest with entries (list of chunk URLs)
+
+3. array_chunk(entries, chunkSize=150)
+   → chunks (groups of 150 slices)
+
+4. Remove PK (if exists):
+   targetClient->removeTablePrimaryKey(tableId)
+
+5. Parallel loop (maxParallelism=3):
+
+   PHASE 1 – Launching worker processes:
+     while free slots:
+       process = new Process([PHP, worker-chunk.php], stdin=json_encode(input))
+       process.start()
+       runningProcesses[chunkIndex] = process
+
+     Collecting completed workers:
+       if process.isSuccessful():
+         result = json_decode(output)  →  {logs, fileId}
+         writeQueue.push({fileId, chunkNum})
+       else:
+         errors.push(RuntimeException)
+
+   PHASE 2 – Sequential SAPI upload (blocking):
+     writeItem = writeQueue.shift()
+     targetClient->writeTableAsyncDirect(tableId, {
+       dataFileId: writeItem.fileId,
+       columns: tableInfo.columns,
+       incremental: true,               ← each chunk is appended
+       useTimestampFromDataFile
+     })
+
+   usleep(100ms)  ← polling
+
+6. After all chunks complete:
+   Restore PK:
+   targetClient->createTablePrimaryKey(tableId, primaryKey)
+```
+
+### worker-chunk.php
+
+Child process for one GCS table chunk:
+
+**Input (STDIN, JSON):**
+```json
+{
+  "sourceApiUrl": "...", "sourceToken": "...",
+  "targetApiUrl": "...", "targetToken": "...",
+  "fileId": 12345,
+  "bucket": "gcs-bucket-name",
+  "chunk": [{"url": "gs://..."}, ...],
+  "optionFileName": "in.c-bucket.table",
+  "chunkNum": 1,
+  "totalChunks": 5
+}
+```
+
+**Output (STDOUT, JSON):**
+```json
+{
+  "logs": ["Downloading slice 1/150 ...", ...],
+  "fileId": "67890"
+}
+```
+
+Worker downloads slices from GCS, uploads them to the destination project's SAPI file storage as a sliced file and returns `fileId`. The main process then uses this file in `writeTableAsyncDirect`.
+
+### Why PK is removed and restored
+
+Snowflake enforces PK uniqueness during `INSERT`. Incremental chunk uploads would cause duplicates (same row in multiple chunks after splitting slices). PK is therefore removed before import and restored after all chunks complete.
+
+---
+
+## Database mode (Snowflake native replication)
+
+### Overview
+
+Database mode uses native Snowflake database replication. Data is not transferred via SAPI – it goes directly Snowflake-to-Snowflake. Significantly faster for large data.
+
+### DatabaseMigrate::migrate() flow
+
+```
+1. targetConnection.useRole('ACCOUNTADMIN')
+
+2. (if shouldCreateReplicaDatabase)
+   CREATE DATABASE IF NOT EXISTS <replicaDb>
+     AS REPLICA OF <region>.<account>.<sourceDb>;
+
+   Also tries lowercase database name variant (compatibility).
+
+3. (if shouldRefreshReplicaDatabase)
+   ALTER DATABASE <replicaDb> REFRESH;
+
+4. targetConnection.useRole(original role)
+
+5. (if shouldMigrateData)
+   migrateData(config)
+
+6. (if shouldDropReplicaDatabase)
+   DROP DATABASE <replicaDb>;
+```
+
+### migrateData() – detail
+
+```
+SHOW SCHEMAS IN DATABASE <replicaDb>
+
+skips schemas:
+  - INFORMATION_SCHEMA
+  - PUBLIC
+  - READER_* (reader schemas)
+  - WORKSPACE_* (unless in includedWorkspaceSchemas)
+
+forEach schema:
+  if bucket does not exist in SAPI: createBucket()
+  migrateSchema(tablesWhiteList, schemaName)
+  refreshTableInformationInBucket(schemaName)  ← notifies SAPI of update
+```
+
+### migrateTable() – detail
+
+```
+getSourceRole(connection, 'TABLE', schemaName.tableName)
+  → SHOW GRANTS ON TABLE → owner (OWNERSHIP privilege)
+
+grantRoleToMigrateUser(tableRole)
+useRole(tableRole)
+grantPrivilegesToReplicaDatabase(replicaDb, tableRole)
+
+compareTableMaxTimestamp():
+  compares MAX(_timestamp) in destination table vs. replicated table
+  → if equal: table is up to date, skip
+
+TRUNCATE TABLE <targetDb>.<schema>.<table>;
+
+INSERT INTO <targetDb>.<schema>.<table> (<cols>)
+  SELECT <cols>
+  FROM <replicaDb>.<schema>.<table>;
+```
+
+### Skipped schemas in database mode
+
+| Schema | Reason for skipping |
+|--------|-----------------|
+| `INFORMATION_SCHEMA` | Snowflake system schema |
+| `PUBLIC` | Default empty schema |
+| `READER_*` | Reader schemas for data sharing (Data Sharing) |
+| `WORKSPACE_*` and `<number>_WORKSPACE*` | Workspaces (regex `^(\d+_)?WORKSPACE`) – included only if explicitly in `includedWorkspaceSchemas` |
+
+### Predefined stack mappings
+
+For standard Keboola stacks, the source Snowflake account and region are predefined in `Config.php` (constant `STACK_URL_TO_SNOWFLAKE_DATABASE`). For other stacks or BYODB, set manually:
+
+```
+isSourceByodb: true
+sourceByodb: database_name
+```
+
+For BYODB there is one predefined value in `Config.php` (`BYODB_DATABASES`): `sourceByodb: "coates"` – other values are treated as direct database names.
+
+### Sync action: createReplications
+
+Before the first database mode migration between two Snowflake stacks, the source project must enable cross-account replication. Sync action `createReplications` (camelCase) runs:
+
+```
+DatabaseReplication::run():
+  ALTER DATABASE <sourceDb>
+    ENABLE REPLICATION TO ACCOUNTS <targetAccount>;
+```
+
+This action must be run in the **source** project using its SAPI token.
+
+---
+
+## Dry-run mode
+
+If `dryRun: true`:
+- No SAPI operations are performed (createBucket, createTable, writeTableAsyncDirect)
+- No Snowflake SQL commands are executed (TRUNCATE, INSERT, CREATE DATABASE)
+- Each skipped operation is logged as `[dry-run] ...`

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,83 @@
+# app-project-migrate-tables-data – overview
+
+## What the component does
+
+Migrates table row data from a source Keboola project to a destination. Run by `app-project-migrate` as Phase 5 of the migration pipeline. Component ID: `keboola.app-project-migrate-large-tables`.
+
+Has two modes: `sapi` (default, via Storage API) and `database` (direct Snowflake replication).
+
+## Migration modes
+
+### sapi
+
+Data flows through Storage API: export from source → upload to shared SAPI file storage → import to destination.
+
+For large GCS tables (sliced + >50 GB), parallel worker processes (`worker-chunk.php`) are used instead of the standard flow.
+
+### database
+
+Uses native Snowflake database replication (`CREATE DATABASE AS REPLICA OF ...`). Significantly faster than sapi mode for large data when migrating between Snowflake stacks.
+
+## What is skipped (sapi mode)
+
+- **Sys bucket** tables (`stage === 'sys'`)
+- **Alias** tables
+
+> External schema and Data Catalog tables are not explicitly skipped in this component – the check happens earlier during the backup phase in `php-kbc-project-backup`. If you migrate a table whitelist, it is your responsibility to exclude them.
+
+## Predefined stack mappings (database mode)
+
+| Stack URL | Snowflake account | Region |
+|---|---|---|
+| `connection.keboola.com` | KEBOOLA | AWS_US_WEST_2 |
+| `connection.eu-central-1.keboola.com` | KEBOOLA | AWS_EU_CENTRAL_1 |
+| `connection.north-europe.azure.keboola.com` | KEBOOLA | AZURE_WESTEUROPE |
+| `connection.europe-west3.gcp.keboola.com` | IK34405 | GCP_EUROPE_WEST4 |
+| `connection.us-east4.gcp.keboola.com` | NE35810 | GCP_US_EAST4 |
+| `connection.coates.keboola.cloud` | KEBOOLA | AWS_US_EAST_1 |
+
+For other stacks or BYODB: `isSourceByodb: true` + `sourceByodb: <database_name>`.
+
+## Sync action: createReplications
+
+`DatabaseReplication` enables Snowflake cross-account replication (`ALTER DATABASE ... ENABLE REPLICATION TO ACCOUNTS ...`). Must be run before the first database mode migration between two stacks. The action name is `createReplications` (camelCase), as registered in `Component::getSyncActions()`.
+
+## Architecture
+
+```
+Component.php
+  ├─ SapiMigrate
+  │    ├─ StorageModifier     – creates buckets and tables in destination
+  │    └─ MigrateGcsLargeTable
+  │         └─ worker-chunk.php  (child process, one per chunk)
+  ├─ DatabaseMigrate
+  │    └─ Snowflake/Connection
+  └─ DatabaseReplication      (sync action)
+```
+
+## Key files
+
+| File | Description |
+|---|---|
+| `src/Component.php` | Entry point, mode routing |
+| `src/Config.php` | Configuration getters + predefined stack-to-Snowflake-DB mappings |
+| `src/ConfigDefinition.php` | Parameter validation |
+| `src/Strategy/SapiMigrate.php` | SAPI transfer logic |
+| `src/Strategy/SapiMigrate/MigrateGcsLargeTable.php` | Parallel worker migration of large GCS tables |
+| `src/Strategy/DatabaseMigrate.php` | Snowflake replication logic |
+| `src/Strategy/DatabaseReplication.php` | Sync action for enabling replication |
+| `src/StorageModifier.php` | Creates buckets and tables in destination project |
+| `src/worker-chunk.php` | Child process: downloads GCS chunk, uploads to SAPI |
+
+## Development and testing
+
+```bash
+docker compose run --rm dev composer phpcs
+docker compose run --rm dev composer phpstan
+docker compose run --rm dev composer tests
+```
+
+## Related repositories
+
+- Used by: `app-project-migrate` (Phase 5)
+- Component ID: `keboola.app-project-migrate-large-tables`

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -61,7 +61,8 @@ Component.php
 |---|---|
 | `src/Component.php` | Entry point, mode routing |
 | `src/Config.php` | Configuration getters + predefined stack-to-Snowflake-DB mappings |
-| `src/ConfigDefinition.php` | Parameter validation |
+| `src/Configuration/ConfigDefinition.php` | Main parameter validation |
+| `src/Configuration/CreateReplicationsConfigDefinition.php` | Validation for the `createReplications` sync action |
 | `src/Strategy/SapiMigrate.php` | SAPI transfer logic |
 | `src/Strategy/SapiMigrate/MigrateGcsLargeTable.php` | Parallel worker migration of large GCS tables |
 | `src/Strategy/DatabaseMigrate.php` | Snowflake replication logic |


### PR DESCRIPTION
Add CLAUDE.md with AI development context, required environment variables, key files and development commands. Add docs/ folder with overview, how-it-works and configuration documentation covering SAPI mode, database mode with native Snowflake replication, GCS large table parallel workers (worker-chunk.php) and predefined stack mappings.