### PR TITLE
fix: add fallback for getMaxTimestamp failure in incremental migration

### DIFF
--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -196,7 +196,16 @@ class SapiMigrate implements MigrateInterface
             return null;
         }
 
-        return $this->getMaxTimestamp($sourceTableInfo['id']);
+        try {
+            return $this->getMaxTimestamp($sourceTableInfo['id']);
+        } catch (ClientException $e) {
+            $this->logger->warning(sprintf(
+                'Cannot resolve changedSince for table %s, falling back to full export: %s',
+                $sourceTableInfo['id'],
+                $e->getMessage(),
+            ));
+            return null;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
Adds a safety net around `getMaxTimestamp()` in `resolveChangedSince()` — if the `_timestamp` export fails for any reason (e.g. unexpected API error), the migration falls back to a full export instead of crashing the entire job.

The `includeInternalTimestamp` fix for typed tables was already applied in the base branch (`cf7a3ff`). This PR only adds the try/catch fallback.

## Review & Testing Checklist for Human
- [ ] Verify incremental migration still works end-to-end (the try/catch should not affect the happy path)

### Notes
- Low risk — only adds error handling around an existing call, no behavior change on success path

Link to Devin session: https://app.devin.ai/sessions/01372625bc494c0faead56b16e836188
Requested by: @yustme