### PR TITLE
feat(sapi-migrate): parallel storage imports + lastChunks diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ The `config.json` configuration file contains the following properties:
     - `sourceKbcToken` - string (required): Storage API token of the source project
     - `tables` - array (optional): List of tables to migrate. If not set, all tables will be migrated.
     - `gcsLargeTable` - object (optional): Configuration for parallel GCS large table migration
-        - `parallelChunks` - integer (optional, default `3`, min `1`, max `20`): Number of chunks to migrate in parallel
-        - `chunkSize` - integer (optional, default `150`, min `1`): Number of slice files per chunk
+        - `parallelChunks` - integer (optional, default `3`, min `1`, max `20`): Number of download/upload worker processes running in parallel
+        - `chunkSize` - integer (optional, default `150`, min `1`): Number of slice files per chunk. Smaller values produce smaller CSV files per Storage API import, which makes it easier to isolate malformed rows when imports fail.
+        - `parallelImports` - integer (optional, default `1`, min `1`, max `20`): Number of concurrent Storage API table imports. Default `1` preserves sequential import behaviour; increase to run multiple `writeTableAsyncDirect`/`queueTableImport` jobs against the target table in parallel. Note: imports use `incremental: true`, so a partial failure can leave the target table half-loaded — drop/truncate the target table before retrying a failed migration.
+        - `lastChunks` - integer (optional, default `0`): If greater than `0`, only the last N chunks are processed (download, upload, and import). The first `(totalChunks - N)` chunks are skipped entirely. Use this for diagnostic bisection when the malformed slice is known to be in the tail of the source table. Chunk numbering in logs stays absolute (e.g. with 68 total chunks and `lastChunks=20`, logs show `Chunk 49/68` … `Chunk 68/68`). Default `0` disables the feature and processes all chunks.
     - `forcePrimaryKeyNotNull` - boolean (optional): If set to `true`, primary key columns will always be created as `NOT NULL` during typed table migration. Useful when source primary key columns are marked nullable but the target backend (e.g. BigQuery) requires primary keys to be non-nullable. Default: `false`.
     - `db` - object (optional in `database` mode; extends the `db` object in `image_parameters`):
         - `host` - string (required): Snowflake host

--- a/src/Component.php
+++ b/src/Component.php
@@ -39,6 +39,8 @@ class Component extends BaseComponent
                     $this->getConfig()->isDryRun(),
                     $this->getConfig()->getGcsLargeTableParallelChunks(),
                     $this->getConfig()->getGcsLargeTableChunkSize(),
+                    $this->getConfig()->getGcsLargeTableParallelImports(),
+                    $this->getConfig()->getGcsLargeTableLastChunks(),
                 );
                 break;
             case 'database':

--- a/src/Config.php
+++ b/src/Config.php
@@ -263,4 +263,14 @@ class Config extends BaseConfig
     {
         return $this->getIntValue(['parameters', 'gcsLargeTable', 'chunkSize'], 150);
     }
+
+    public function getGcsLargeTableParallelImports(): int
+    {
+        return $this->getIntValue(['parameters', 'gcsLargeTable', 'parallelImports'], 1);
+    }
+
+    public function getGcsLargeTableLastChunks(): int
+    {
+        return $this->getIntValue(['parameters', 'gcsLargeTable', 'lastChunks'], 0);
+    }
 }

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -33,6 +33,8 @@ class ConfigDefinition extends BaseConfigDefinition
                     ->children()
                         ->integerNode('parallelChunks')->defaultValue(3)->min(1)->max(20)->end()
                         ->integerNode('chunkSize')->defaultValue(150)->min(1)->end()
+                        ->integerNode('parallelImports')->defaultValue(1)->min(1)->max(20)->end()
+                        ->integerNode('lastChunks')->defaultValue(0)->min(0)->end()
                     ->end()
                 ->end()
                 ->arrayNode('replica')

--- a/src/Strategy/SapiMigrate.php
+++ b/src/Strategy/SapiMigrate.php
@@ -33,6 +33,8 @@ class SapiMigrate implements MigrateInterface
         private readonly bool $dryRun = false,
         private readonly int $parallelChunks = 3,
         private readonly int $chunkSize = 150,
+        private readonly int $parallelImports = 1,
+        private readonly int $lastChunks = 0,
     ) {
         $this->storageModifier = new StorageModifier($this->targetClient);
         $this->migrateGcsLargeTable = new MigrateGcsLargeTable(
@@ -42,6 +44,8 @@ class SapiMigrate implements MigrateInterface
             $this->dryRun,
             $this->parallelChunks,
             $this->chunkSize,
+            $this->parallelImports,
+            $this->lastChunks,
         );
     }
 

--- a/src/Strategy/SapiMigrate/MigrateGcsLargeTable.php
+++ b/src/Strategy/SapiMigrate/MigrateGcsLargeTable.php
@@ -13,6 +13,7 @@ use Keboola\StorageApi\Options\GetFileOptions;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Symfony\Component\Process\Process;
+use Throwable;
 
 class MigrateGcsLargeTable
 {
@@ -23,6 +24,8 @@ class MigrateGcsLargeTable
         private readonly bool $dryRun = false,
         private readonly int $maxParallelism = 3,
         private readonly int $chunkSize = 150,
+        private readonly int $parallelImports = 1,
+        private readonly int $lastChunks = 0,
     ) {
     }
 
@@ -62,11 +65,24 @@ class MigrateGcsLargeTable
         $chunks = array_chunk((array) $manifest['entries'], max(1, $this->chunkSize));
 
         $totalChunks = count($chunks);
+        $startChunkIndex = 0;
+        if ($this->lastChunks > 0 && $this->lastChunks < $totalChunks) {
+            $startChunkIndex = $totalChunks - $this->lastChunks;
+            $this->logger->info(sprintf(
+                'lastChunks=%d set: skipping chunks 1-%d, processing only chunks %d-%d',
+                $this->lastChunks,
+                $startChunkIndex,
+                $startChunkIndex + 1,
+                $totalChunks,
+            ));
+        }
+
         $this->logger->info(sprintf(
-            'Processing table %s: %d chunks with parallelism %d',
+            'Processing table %s: %d chunks (worker parallelism %d, import parallelism %d)',
             $tableInfo['id'],
-            $totalChunks,
+            $totalChunks - $startChunkIndex,
             $this->maxParallelism,
+            $this->parallelImports,
         ));
 
         $sourceApiUrl = $this->sourceClient->getApiUrl();
@@ -89,17 +105,26 @@ class MigrateGcsLargeTable
         $runningProcesses = [];
         /** @var array<array{fileId: string, chunkNum: int}> $writeQueue */
         $writeQueue = [];
+        /** @var array<int, array{jobId: int, chunkNum: int, fileId: string}> $inFlightImports */
+        $inFlightImports = [];
         $errors = [];
-        $chunkIndex = 0;
+        $chunkIndex = $startChunkIndex;
 
         try {
-            while ($chunkIndex < $totalChunks || !empty($runningProcesses) || !empty($writeQueue)) {
-                // --- Phase 1: collect finished workers (free slots before starting new ones) ---
+            while ($chunkIndex < $totalChunks
+                || !empty($runningProcesses)
+                || !empty($writeQueue)
+                || !empty($inFlightImports)
+            ) {
+                $didSomething = false;
+
+                // --- Phase 1a: collect finished workers (free slots before starting new ones) ---
                 foreach ($runningProcesses as $key => $item) {
                     if (!$item['process']->isRunning()) {
                         unset($runningProcesses[$key]);
+                        $didSomething = true;
                         if (!$item['process']->isSuccessful()) {
-                            $errors[$key] = new RuntimeException(sprintf(
+                            $errors['worker-' . $key] = new RuntimeException(sprintf(
                                 'Chunk %d/%d worker exited with code %d: %s',
                                 $item['chunkNum'],
                                 $totalChunks,
@@ -112,7 +137,7 @@ class MigrateGcsLargeTable
                             /** @var array{logs: string[], fileId: string} $result */
                             $result = json_decode($item['process']->getOutput(), true, 512, JSON_THROW_ON_ERROR);
                         } catch (JsonException $e) {
-                            $errors[$key] = new RuntimeException(sprintf(
+                            $errors['worker-' . $key] = new RuntimeException(sprintf(
                                 'Chunk %d/%d worker returned invalid JSON: %s',
                                 $item['chunkNum'],
                                 $totalChunks,
@@ -127,7 +152,7 @@ class MigrateGcsLargeTable
                     }
                 }
 
-                // --- Phase 1: start new workers into freed slots ---
+                // --- Phase 1b: start new workers into freed slots ---
                 while ($chunkIndex < $totalChunks && count($runningProcesses) < max(1, $this->maxParallelism)) {
                     $chunkNum = $chunkIndex + 1;
                     $this->logger->info(sprintf(
@@ -151,34 +176,81 @@ class MigrateGcsLargeTable
                     $process->start();
                     $runningProcesses[$chunkIndex] = ['process' => $process, 'chunkNum' => $chunkNum];
                     $chunkIndex++;
+                    $didSomething = true;
                 }
 
-                // --- Phase 2: process first item from writeQueue (blocking) ---
-                // Phase 1 workers continue running in the OS during this blocking call.
-                if (!empty($writeQueue)) {
+                // --- Phase 2a: reap finished SAPI import jobs ---
+                foreach ($inFlightImports as $key => $item) {
+                    try {
+                        $job = $this->targetClient->getJob($item['jobId']);
+                    } catch (Throwable $e) {
+                        unset($inFlightImports[$key]);
+                        $errors['import-' . $key] = new RuntimeException(sprintf(
+                            'Chunk %d/%d: polling import job %d failed: %s',
+                            $item['chunkNum'],
+                            $totalChunks,
+                            $item['jobId'],
+                            $e->getMessage(),
+                        ), 0, $e);
+                        $didSomething = true;
+                        continue;
+                    }
+                    $status = (string) $job['status'];
+                    if (!in_array($status, ['success', 'error'], true)) {
+                        continue; // still waiting/processing
+                    }
+                    unset($inFlightImports[$key]);
+                    $didSomething = true;
+                    if ($status === 'success') {
+                        $this->logger->info(sprintf(
+                            'Finished chunk %d/%d (import job %d)',
+                            $item['chunkNum'],
+                            $totalChunks,
+                            $item['jobId'],
+                        ));
+                    } else {
+                        $errors['import-' . $key] = new RuntimeException(sprintf(
+                            'Chunk %d/%d import job %d failed: %s (fileId: %s)',
+                            $item['chunkNum'],
+                            $totalChunks,
+                            $item['jobId'],
+                            $job['error']['message'] ?? '(no error message)',
+                            $item['fileId'],
+                        ));
+                    }
+                }
+
+                // --- Phase 2b: enqueue new SAPI imports up to parallelImports ---
+                while (!empty($writeQueue) && count($inFlightImports) < max(1, $this->parallelImports)) {
                     $writeItem = array_shift($writeQueue);
                     $this->logger->info(sprintf(
-                        'Chunk %d/%d: importing into table %s (fileId: %s)',
+                        'Chunk %d/%d: starting import into table %s (fileId: %s)',
                         $writeItem['chunkNum'],
                         $totalChunks,
                         $tableInfo['id'],
                         $writeItem['fileId'],
                     ));
-                    $this->targetClient->writeTableAsyncDirect($tableInfo['id'], [
+                    $jobId = $this->targetClient->queueTableImport($tableInfo['id'], [
                         'name' => $tableInfo['name'],
                         'dataFileId' => $writeItem['fileId'],
                         'columns' => $tableInfo['columns'],
                         'useTimestampFromDataFile' => $preserveTimestamp,
                         'incremental' => true,
                     ]);
-                    $this->logger->info(sprintf('Finished chunk %d/%d', $writeItem['chunkNum'], $totalChunks));
-                    continue;
+                    $inFlightImports[$writeItem['chunkNum']] = [
+                        'jobId' => (int) $jobId,
+                        'chunkNum' => $writeItem['chunkNum'],
+                        'fileId' => $writeItem['fileId'],
+                    ];
+                    $didSomething = true;
                 }
 
-                usleep(100_000); // 100ms polling — nothing to process yet
+                if (!$didSomething) {
+                    usleep(1_000_000); // 1s — nothing to process, back off polling
+                }
             }
 
-            $this->logger->info(sprintf('All %d chunks processed', $totalChunks));
+            $this->logger->info(sprintf('All %d chunks processed', $totalChunks - $startChunkIndex));
         } finally {
             foreach ($runningProcesses as $item) {
                 $item['process']->stop(0);

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -28,6 +28,8 @@ class ConfigTest extends TestCase
 
         self::assertSame(3, $config->getGcsLargeTableParallelChunks());
         self::assertSame(150, $config->getGcsLargeTableChunkSize());
+        self::assertSame(1, $config->getGcsLargeTableParallelImports());
+        self::assertSame(0, $config->getGcsLargeTableLastChunks());
     }
 
     public function testGcsLargeTableCustomValues(): void
@@ -38,11 +40,66 @@ class ConfigTest extends TestCase
             'gcsLargeTable' => [
                 'parallelChunks' => 5,
                 'chunkSize' => 200,
+                'parallelImports' => 4,
+                'lastChunks' => 20,
             ],
         ]);
 
         self::assertSame(5, $config->getGcsLargeTableParallelChunks());
         self::assertSame(200, $config->getGcsLargeTableChunkSize());
+        self::assertSame(4, $config->getGcsLargeTableParallelImports());
+        self::assertSame(20, $config->getGcsLargeTableLastChunks());
+    }
+
+    public function testParallelImportsMinimumIsOne(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage(
+            'The value 0 is too small for path "root.parameters.gcsLargeTable.parallelImports". ' .
+            'Should be greater than or equal to 1',
+        );
+
+        $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+            'gcsLargeTable' => [
+                'parallelImports' => 0,
+            ],
+        ]);
+    }
+
+    public function testParallelImportsMaximumIsTwenty(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage(
+            'The value 21 is too big for path "root.parameters.gcsLargeTable.parallelImports". ' .
+            'Should be less than or equal to 20',
+        );
+
+        $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+            'gcsLargeTable' => [
+                'parallelImports' => 21,
+            ],
+        ]);
+    }
+
+    public function testLastChunksMinimumIsZero(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage(
+            'The value -1 is too small for path "root.parameters.gcsLargeTable.lastChunks". ' .
+            'Should be greater than or equal to 0',
+        );
+
+        $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+            'gcsLargeTable' => [
+                'lastChunks' => -1,
+            ],
+        ]);
     }
 
     public function testParallelChunksMinimumIsOne(): void

--- a/tests/phpunit/MigrateGcsLargeTableTest.php
+++ b/tests/phpunit/MigrateGcsLargeTableTest.php
@@ -80,7 +80,7 @@ class MigrateGcsLargeTableTest extends TestCase
 
         $targetClient = $this->createMock(Client::class);
         $targetClient->expects($this->never())->method('getTable');
-        $targetClient->expects($this->never())->method('writeTableAsyncDirect');
+        $targetClient->expects($this->never())->method('queueTableImport');
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects($this->once())
@@ -101,7 +101,8 @@ class MigrateGcsLargeTableTest extends TestCase
         $targetClient->expects($this->once())->method('getTable')->with($tableId)->willReturn(['primaryKey' => ['id']]);
         $targetClient->expects($this->once())->method('removeTablePrimaryKey')->with($tableId);
         $targetClient->expects($this->once())->method('createTablePrimaryKey')->with($tableId, ['id']);
-        $targetClient->expects($this->once())->method('writeTableAsyncDirect');
+        $targetClient->expects($this->once())->method('queueTableImport')->willReturn(999);
+        $targetClient->expects($this->once())->method('getJob')->with(999)->willReturn(['status' => 'success']);
 
         $migrator = new MigrateGcsLargeTable(
             $this->buildSourceClient(),
@@ -153,11 +154,21 @@ class MigrateGcsLargeTableTest extends TestCase
     {
         $tableId = 'in.c-test.my_table';
 
+        $jobIds = [];
         $targetClient = $this->createMock(Client::class);
         $targetClient->expects($this->once())->method('getApiUrl')->willReturn('https://connection.keboola.com');
         $targetClient->expects($this->once())->method('getTokenString')->willReturn('target-token');
         $targetClient->expects($this->once())->method('getTable')->willReturn(['primaryKey' => []]);
-        $targetClient->expects($this->exactly(3))->method('writeTableAsyncDirect');
+        $targetClient->expects($this->exactly(3))
+            ->method('queueTableImport')
+            ->willReturnCallback(function () use (&$jobIds): int {
+                $jobId = 100 + count($jobIds);
+                $jobIds[] = $jobId;
+                return $jobId;
+            });
+        $targetClient->expects($this->exactly(3))
+            ->method('getJob')
+            ->willReturn(['status' => 'success']);
 
         $migrator = new MigrateGcsLargeTable(
             $this->buildSourceClient(),
@@ -188,7 +199,7 @@ class MigrateGcsLargeTableTest extends TestCase
         $targetClient->expects($this->once())->method('getApiUrl')->willReturn('https://connection.keboola.com');
         $targetClient->expects($this->once())->method('getTokenString')->willReturn('target-token');
         $targetClient->expects($this->once())->method('getTable')->willReturn(['primaryKey' => []]);
-        $targetClient->expects($this->never())->method('writeTableAsyncDirect');
+        $targetClient->expects($this->never())->method('queueTableImport');
 
         $migrator = new MigrateGcsLargeTable(
             $this->buildSourceClient(),
@@ -224,7 +235,8 @@ class MigrateGcsLargeTableTest extends TestCase
         $targetClient->expects($this->once())->method('getTable')->willReturn(['primaryKey' => []]);
         $targetClient->expects($this->never())->method('removeTablePrimaryKey');
         $targetClient->expects($this->never())->method('createTablePrimaryKey');
-        $targetClient->expects($this->once())->method('writeTableAsyncDirect');
+        $targetClient->expects($this->once())->method('queueTableImport')->willReturn(999);
+        $targetClient->expects($this->once())->method('getJob')->willReturn(['status' => 'success']);
 
         $migrator = new MigrateGcsLargeTable(
             $this->buildSourceClient(),
@@ -232,6 +244,7 @@ class MigrateGcsLargeTableTest extends TestCase
             $this->createMock(LoggerInterface::class),
             chunkSize: 999,
         );
+
         $migrator->migrate(
             123,
             ['id' => $tableId, 'name' => 'my_table', 'columns' => ['id', 'name']],
@@ -239,5 +252,190 @@ class MigrateGcsLargeTableTest extends TestCase
             $this->buildGcsClientFactory([['url' => 'gs://test-bucket/path/slice1']]),
             $this->buildSuccessfulProcessFactory(),
         );
+    }
+
+    public function testFailedImportJobIsReportedWithChunkNumber(): void
+    {
+        $tableId = 'in.c-test.my_table';
+
+        $targetClient = $this->createMock(Client::class);
+        $targetClient->expects($this->once())->method('getApiUrl')->willReturn('https://connection.keboola.com');
+        $targetClient->expects($this->once())->method('getTokenString')->willReturn('target-token');
+        $targetClient->expects($this->once())->method('getTable')->willReturn(['primaryKey' => []]);
+        $targetClient->expects($this->once())->method('queueTableImport')->willReturn(777);
+        $targetClient->expects($this->once())->method('getJob')->with(777)->willReturn([
+            'status' => 'error',
+            'error' => ['message' => 'CSV processing encountered too many errors'],
+        ]);
+
+        $migrator = new MigrateGcsLargeTable(
+            $this->buildSourceClient(),
+            $targetClient,
+            $this->createMock(LoggerInterface::class),
+            chunkSize: 999,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage(
+            'Failed 1 chunk(s). First: Chunk 1/1 import job 777 failed: '
+            . 'CSV processing encountered too many errors (fileId: 42)',
+        );
+
+        $migrator->migrate(
+            123,
+            ['id' => $tableId, 'name' => 'my_table', 'columns' => ['id', 'name']],
+            false,
+            $this->buildGcsClientFactory([['url' => 'gs://test-bucket/path/slice1']]),
+            $this->buildSuccessfulProcessFactory(),
+        );
+    }
+
+    public function testParallelImportsRunMultipleJobsConcurrently(): void
+    {
+        $tableId = 'in.c-test.my_table';
+
+        $queuedJobs = [];
+        $targetClient = $this->createMock(Client::class);
+        $targetClient->expects($this->once())->method('getApiUrl')->willReturn('https://connection.keboola.com');
+        $targetClient->expects($this->once())->method('getTokenString')->willReturn('target-token');
+        $targetClient->expects($this->once())->method('getTable')->willReturn(['primaryKey' => []]);
+        $targetClient->expects($this->exactly(3))
+            ->method('queueTableImport')
+            ->willReturnCallback(function () use (&$queuedJobs): int {
+                $jobId = 200 + count($queuedJobs);
+                $queuedJobs[] = $jobId;
+                return $jobId;
+            });
+        // With parallelImports=3 all three jobs should be in-flight before any getJob succeeds.
+        $targetClient->expects($this->exactly(3))
+            ->method('getJob')
+            ->willReturnCallback(function (int $jobId) use (&$queuedJobs): array {
+                // All three jobs must have been queued before the first getJob poll resolves.
+                self::assertCount(3, $queuedJobs, sprintf(
+                    'getJob(%d) called while only %d jobs queued (expected all 3 to be queued first)',
+                    $jobId,
+                    count($queuedJobs),
+                ));
+                return ['status' => 'success'];
+            });
+
+        $migrator = new MigrateGcsLargeTable(
+            $this->buildSourceClient(),
+            $targetClient,
+            $this->createMock(LoggerInterface::class),
+            maxParallelism: 3,
+            chunkSize: 1,
+            parallelImports: 3,
+        );
+
+        $migrator->migrate(
+            123,
+            ['id' => $tableId, 'name' => 'my_table', 'columns' => ['id', 'name']],
+            false,
+            $this->buildGcsClientFactory([
+                ['url' => 'gs://test-bucket/path/slice1'],
+                ['url' => 'gs://test-bucket/path/slice2'],
+                ['url' => 'gs://test-bucket/path/slice3'],
+            ]),
+            $this->buildSuccessfulProcessFactory(),
+        );
+    }
+
+    public function testLastChunksProcessesOnlyTrailingChunks(): void
+    {
+        $tableId = 'in.c-test.my_table';
+
+        $startedChunkNums = [];
+        $processFactory = function (array $input) use (&$startedChunkNums): Process {
+            $startedChunkNums[] = $input['chunkNum'];
+            $process = $this->createMock(Process::class);
+            $process->method('start');
+            $process->method('isRunning')->willReturn(false);
+            $process->method('isSuccessful')->willReturn(true);
+            $process->method('getOutput')->willReturn(json_encode([
+                'fileId' => '42',
+                'logs' => [],
+            ]));
+            return $process;
+        };
+
+        $targetClient = $this->createMock(Client::class);
+        $targetClient->expects($this->once())->method('getApiUrl')->willReturn('https://connection.keboola.com');
+        $targetClient->expects($this->once())->method('getTokenString')->willReturn('target-token');
+        $targetClient->expects($this->once())->method('getTable')->willReturn(['primaryKey' => []]);
+        // 5 total chunks, lastChunks=2 → only chunks 4 and 5 are imported.
+        $targetClient->expects($this->exactly(2))->method('queueTableImport')->willReturn(123);
+        $targetClient->expects($this->exactly(2))->method('getJob')->willReturn(['status' => 'success']);
+
+        $migrator = new MigrateGcsLargeTable(
+            $this->buildSourceClient(),
+            $targetClient,
+            $this->createMock(LoggerInterface::class),
+            chunkSize: 1,
+            lastChunks: 2,
+        );
+
+        $migrator->migrate(
+            123,
+            ['id' => $tableId, 'name' => 'my_table', 'columns' => ['id', 'name']],
+            false,
+            $this->buildGcsClientFactory([
+                ['url' => 'gs://test-bucket/path/slice1'],
+                ['url' => 'gs://test-bucket/path/slice2'],
+                ['url' => 'gs://test-bucket/path/slice3'],
+                ['url' => 'gs://test-bucket/path/slice4'],
+                ['url' => 'gs://test-bucket/path/slice5'],
+            ]),
+            $processFactory,
+        );
+
+        self::assertSame([4, 5], $startedChunkNums);
+    }
+
+    public function testLastChunksLargerThanTotalProcessesAll(): void
+    {
+        $tableId = 'in.c-test.my_table';
+
+        $startedChunkNums = [];
+        $processFactory = function (array $input) use (&$startedChunkNums): Process {
+            $startedChunkNums[] = $input['chunkNum'];
+            $process = $this->createMock(Process::class);
+            $process->method('start');
+            $process->method('isRunning')->willReturn(false);
+            $process->method('isSuccessful')->willReturn(true);
+            $process->method('getOutput')->willReturn(json_encode([
+                'fileId' => '42',
+                'logs' => [],
+            ]));
+            return $process;
+        };
+
+        $targetClient = $this->createMock(Client::class);
+        $targetClient->expects($this->once())->method('getApiUrl')->willReturn('https://connection.keboola.com');
+        $targetClient->expects($this->once())->method('getTokenString')->willReturn('target-token');
+        $targetClient->expects($this->once())->method('getTable')->willReturn(['primaryKey' => []]);
+        $targetClient->expects($this->exactly(2))->method('queueTableImport')->willReturn(123);
+        $targetClient->expects($this->exactly(2))->method('getJob')->willReturn(['status' => 'success']);
+
+        $migrator = new MigrateGcsLargeTable(
+            $this->buildSourceClient(),
+            $targetClient,
+            $this->createMock(LoggerInterface::class),
+            chunkSize: 1,
+            lastChunks: 99,
+        );
+
+        $migrator->migrate(
+            123,
+            ['id' => $tableId, 'name' => 'my_table', 'columns' => ['id', 'name']],
+            false,
+            $this->buildGcsClientFactory([
+                ['url' => 'gs://test-bucket/path/slice1'],
+                ['url' => 'gs://test-bucket/path/slice2'],
+            ]),
+            $processFactory,
+        );
+
+        self::assertSame([1, 2], $startedChunkNums);
     }
 }


### PR DESCRIPTION
## Summary

Adds two new options to the `gcsLargeTable` section of the configuration to make the large-table SAPI migration path faster (parallel imports) and easier to debug when an individual chunk fails (skip-first-N chunks).

### Changes
- **`parallelImports`** (integer, default `1`, min `1`, max `20`) — number of concurrent Storage API table imports. Until now `MigrateGcsLargeTable::migrate` ran one `writeTableAsyncDirect` at a time and blocked on the storage tableImport job; download/upload workers ran in parallel but the import phase was strictly serialized. This PR replaces the blocking call with `queueTableImport` + `getJob` polling so that up to `parallelImports` imports can be in flight against the target table at once. Default `1` preserves existing sequential behaviour.
- **`lastChunks`** (integer, default `0`) — when `> 0`, only the last `N` chunks are processed (download, upload, AND import). The first `(totalChunks - N)` chunks are skipped entirely — no slice files are downloaded for those chunks. Useful for bisecting which chunk contains a malformed row (e.g. the recent BQ `CSV processing encountered too many errors. Rows: N; errors: 1` failures on `cdt_conversion_measurement_order`). Chunk numbering in logs/errors stays absolute (e.g. with 68 total chunks and `lastChunks=20`, you'll see `Chunk 49/68 …` through `Chunk 68/68 …`).
- Failed import jobs now produce error messages that include the chunk number, storage job id, file id of the staged chunk, and the underlying error message — making it easy to identify which specific import is failing and which staged file to load into DuckDB for inspection.

### Wiring
- `Configuration/ConfigDefinition.php` — two new integer nodes under `gcsLargeTable`.
- `Config.php` — getters `getGcsLargeTableParallelImports()` and `getGcsLargeTableLastChunks()`.
- `Component.php` — pass both new values into the `SapiMigrate` constructor.
- `Strategy/SapiMigrate.php` — accept both parameters and forward to `MigrateGcsLargeTable`.
- `Strategy/SapiMigrate/MigrateGcsLargeTable.php` — refactored main loop to track `inFlightImports` map, poll via `getJob`, enforce the new `parallelImports` cap, and start at `chunkIndex = totalChunks - lastChunks` when applicable.

### Example
```json
{
  "parameters": {
    "gcsLargeTable": {
      "parallelChunks": 3,
      "chunkSize": 15,
      "parallelImports": 3,
      "lastChunks": 20
    }
  }
}
```

### Important caveat (existing bug, not addressed in this PR)
The large-table path imports chunks with `incremental: true` and `finally` always restores the primary key. With sequential imports this already produces a half-loaded-but-PK-restored target table on partial failure. With `parallelImports > 1` this amplifies — more chunks land in the target before a failure aborts the run. **Drop/truncate the target table before any retry.** A follow-up PR will fix this (skip `createTablePrimaryKey` when an error has been recorded, and use `incremental: false` for the first chunk).

## Review & Testing Checklist for Human

- [ ] Verify default behaviour is unchanged: with no `gcsLargeTable.parallelImports` or `lastChunks` set, the migration should behave identically to the previous release (one import at a time, all chunks processed). Defaults are `1` and `0` respectively.
- [ ] Test the diagnostic flow on the failing `cdt_conversion_measurement_order` table: `chunkSize: 15, parallelImports: 3, lastChunks: 20` should download only 300 slices (instead of 1010), run 3 concurrent imports, and on failure produce an error naming the specific chunk number and storage job ID that failed.
- [ ] After testing, confirm whether `parallelImports > 1` causes any SAPI rate-limiting or quota issues against the target stack (com-keboola-gcp-europe-west3, project 2743). BigQuery itself accepts concurrent LOAD jobs; the open question is whether the connection-worker tableImport pipeline has any per-target-table serialization we'd hit.
- [ ] Decide on the follow-up PR for the partial-state bug — it's worth doing soon, otherwise the increased blast radius from parallel imports makes failed runs harder to recover from.

### Notes
- The refactor switches from the blocking `Client::writeTableAsyncDirect` to the non-blocking `Client::queueTableImport` + manual `Client::getJob` polling. Even with `parallelImports=1` this is a behaviour change in the sense that the import is now polled by us rather than by `apiPostJson(..., wait=true)`. SAPI terminal states are `success`/`error` (see `Client::waitForJob`), and we handle both.
- Polling interval: 1 s when the loop has nothing else to do, 0 s when there's work to process. With `parallelImports=3` that's ~3 `getJob` calls/sec at idle, which matches the SAPI client's own `waitForJob` retry cadence.
- Tests: `MigrateGcsLargeTableTest` was updated to mock `queueTableImport` + `getJob` instead of `writeTableAsyncDirect`; new tests cover the parallel-imports concurrency guarantee and `lastChunks` skipping behaviour. `ConfigTest` covers default values and min/max validation for both new options. All 39 unit tests pass; phpcs + phpstan (level max) pass.

Link to Devin session: https://app.devin.ai/sessions/890f7a46b8244add81ff62bf423df0c6
Requested by: @yustme