### PR TITLE
[AJDA-2603] Add optional Snowflake Replication Group support for database mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Keboola App component for direct table data migration between projects. Run by `app-project-migrate` as Phase 5 of the pipeline. Component ID: `keboola.app-project-migrate-large-tables`.
 
-Has two modes: `sapi` (via Storage API) and `database` (via Snowflake replication).
+Has two modes: `sapi` (via Storage API) and `database` (via Snowflake replication). Database mode supports two replication strategies via `replicationStrategy`: `standalone` (default) and `group` (uses a Snowflake Replication Group to avoid materializing cross-DB zero-copy clones).
 
 ## Documentation
 
@@ -60,6 +60,7 @@ docker compose run --rm dev composer build           # phplint + phpcs + phpstan
 | `src/Strategy/SapiMigrate/MigrateGcsLargeTable.php` | Parallel worker migration of large GCS tables |
 | `src/Strategy/DatabaseMigrate.php` | Snowflake replication logic |
 | `src/Strategy/DatabaseReplication.php` | Sync action for enabling replication |
+| `src/Strategy/ReplicationGroup.php` | Builds Replication Group SQL (CREATE/ALTER/REFRESH/DROP) for database mode |
 | `src/Snowflake/Connection.php` | Snowflake DB connection wrapper (grants, role handling) |
 | `src/StorageModifier.php` | Creates buckets and tables in destination project (incl. cross-backend type mapping) |
 | `src/worker-chunk.php` | Child process: downloads GCS chunk, uploads to SAPI |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Used in database mode:
 | connection.keboola.com | KEBOOLA | AWS_US_WEST_2 |
 | connection.eu-central-1.keboola.com | KEBOOLA | AWS_EU_CENTRAL_1 |
 | connection.north-europe.azure.keboola.com | KEBOOLA | AZURE_WESTEUROPE |
-| connection.europe-west3.gcp.keboola.com | IK34405 | GCP_EUROPE_WEST4 |
+| connection.europe-west3.gcp.keboola.com | PJ41720 | GCP_EUROPE_WEST3 |
 | connection.us-east4.gcp.keboola.com | NE35810 | GCP_US_EAST4 |
 | connection.coates.keboola.cloud | KEBOOLA | AWS_US_EAST_1 |
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,35 @@ ALTER DATABASE {{SOURCE_DATABASE_NAME}} ENABLE REPLICATION TO ACCOUNTS {{DESTINA
 
 If these conditions are not met, please use SAPI mode.
 
+#### Replication Group (`replicationStrategy: group`)
+
+Instead of replicating each database independently, the application can use a Snowflake **Replication Group**, which keeps related databases together and preserves cross-database zero-copy clones (avoiding storage inflation). The application performs the SQL below automatically; this is what it does under the hood (and how you would set it up manually).
+
+On the **source** account, create the replication group spanning the related databases:
+```sql
+CREATE REPLICATION GROUP {{REPLICATION_GROUP_NAME}}
+  OBJECT_TYPES = DATABASES
+  ALLOWED_DATABASES = {{SOURCE_DATABASE_1}}, {{SOURCE_DATABASE_2}}
+  ALLOWED_ACCOUNTS = {{DESTINATION_ORG_NAME}}.{{DESTINATION_ACCOUNT_NAME}};
+```
+
+On the **destination** account, create a replica of the group and refresh it:
+```sql
+CREATE REPLICATION GROUP {{REPLICATION_GROUP_NAME}}
+  AS REPLICA OF {{SOURCE_ORG_NAME}}.{{SOURCE_ACCOUNT_NAME}}.{{REPLICATION_GROUP_NAME}};
+ALTER REPLICATION GROUP {{REPLICATION_GROUP_NAME}} REFRESH;
+```
+
+The member databases then appear on the destination under their original source names. Once all of them are migrated, the group is removed:
+```sql
+DROP REPLICATION GROUP IF EXISTS {{REPLICATION_GROUP_NAME}};
+```
+
+Notes:
+- The `org_name.account_name` identifiers come from `SELECT CURRENT_ORGANIZATION_NAME(), CURRENT_ACCOUNT_NAME();` run on the respective account (note the `org.account` format, **not** `region.account` used by standalone replication).
+- Because group members keep their source names and cannot be renamed, this strategy is not supported between stacks that share the same database prefix (the replicated database would collide with a destination-owned one) — use `standalone` for those.
+- The group is shared by all per-project runs migrating its member databases, so a single run does not drop it by default (`replica.drop` defaults to `false` in group mode); the group is torn down once after all databases are migrated.
+
 ## Configuration
 
 The `config.json` configuration file contains the following properties:
@@ -45,6 +74,9 @@ The `config.json` configuration file contains the following properties:
         - `parallelChunks` - integer (optional, default `3`, min `1`, max `20`): Number of chunks to migrate in parallel
         - `chunkSize` - integer (optional, default `150`, min `1`): Number of slice files per chunk
     - `forcePrimaryKeyNotNull` - boolean (optional): If set to `true`, primary key columns will always be created as `NOT NULL` during typed table migration. Useful when source primary key columns are marked nullable but the target backend (e.g. BigQuery) requires primary keys to be non-nullable. Default: `false`.
+    - `replicationStrategy` - string (optional, `database` mode): `standalone` (default) replicates each project database independently; `group` uses a Snowflake Replication Group to preserve cross-database zero-copy clones and avoid storage inflation.
+    - `replicationGroup` - object (optional, required when `replicationStrategy` is `group`):
+        - `name` - string (required): Replication group name. The source account identifier is derived automatically from `sourceKbcUrl`, and each run migrates the single project database it resolves from the project id — no database list is needed here. **Restriction:** `group` is rejected when the source and target stacks share the same database prefix (the replicated database would collide with a destination-owned one). Use `standalone` for such stack pairs.
     - `db` - object (optional in `database` mode; extends the `db` object in `image_parameters`):
         - `host` - string (required): Snowflake host
         - `username` - string (required): Snowflake username
@@ -92,6 +124,22 @@ The `config.json` configuration file contains the following properties:
     "mode": "database",
     "sourceKbcUrl": "https://connection.keboola.com/",
     "#sourceKbcToken": "SOURCE_KBC_TOKEN"
+  }
+}
+```
+
+### Database mode with Replication Group
+
+```json
+{
+  "parameters": {
+    "mode": "database",
+    "sourceKbcUrl": "https://connection.keboola.com/",
+    "#sourceKbcToken": "SOURCE_KBC_TOKEN",
+    "replicationStrategy": "group",
+    "replicationGroup": {
+      "name": "MIGRATE_RG_1234"
+    }
   }
 }
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ Required if `mode: database`. Ignored if `mode: sapi`.
 |---|---|---|
 | `replica.create` | `true` | Creates replica database |
 | `replica.refresh` | `true` | Refreshes replica before migration |
-| `replica.drop` | `true` | Drops replica database after migration |
+| `replica.drop` | `true` (standalone) / `false` (group) | Drops the replica after migration. In `group` mode the default is `false`: the replication group is shared by all per-project runs migrating its member databases, so a single run must not tear it down — drop it once after all databases are migrated (or set `true` explicitly). |
 
 > The TRUNCATE + INSERT from replica to destination is controlled by the `migrateData` parameter (see General parameters) – it is at the `parameters` level, not under `replica`.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,15 @@ Required if `mode: database`. Ignored if `mode: sapi`.
 
 > Predefined stack-to-Snowflake-account mappings are in `src/Config.php`. To add a new stack, extend this mapping.
 
+### Replication strategy
+
+| Parameter | Default | Description |
+|---|---|---|
+| `replicationStrategy` | `standalone` | `standalone` = per-database replication (default, backward compatible). `group` = Snowflake Replication Group, preserves cross-database zero-copy clones to avoid storage inflation. |
+| `replicationGroup.name` | – | Replication group name. Required when `replicationStrategy: group`. Must be the SAME name on the primary (`createReplications`) and secondary (`run`) sides — the caller supplies it. |
+| `replicationGroup.databases` | – | Explicit list of source databases that form the group (used as `ALLOWED_DATABASES` on the primary, and iterated for data copy on the secondary). Required when `replicationStrategy: group`. |
+| `replicationGroup.sourceAccountIdentifier` | – | Source account in `org_name.account_name` format. Run action only. Populated by the orchestrator (`app-project-migrate`). Required when `replicationStrategy: group`. |
+
 ## Configuration examples
 
 ### SAPI mode (default)
@@ -137,6 +146,30 @@ Required if `mode: database`. Ignored if `mode: sapi`.
     "#sourceKbcToken": "xxx",
     "isSourceByodb": true,
     "sourceByodb": "CUSTOMER_DB_NAME",
+    "db": {
+      "host": "keboola.snowflakecomputing.com",
+      "username": "svc_migrate",
+      "#password": "secret",
+      "warehouse": "MIGRATE_WH"
+    }
+  }
+}
+```
+
+### Database mode with Replication Group
+
+```json
+{
+  "parameters": {
+    "mode": "database",
+    "sourceKbcUrl": "https://connection.keboola.com",
+    "#sourceKbcToken": "xxx",
+    "replicationStrategy": "group",
+    "replicationGroup": {
+      "name": "MIGRATE_RG_1234",
+      "sourceAccountIdentifier": "MYORG.SOURCEACCT",
+      "databases": ["SAPI_1234", "SAPI_5678"]
+    },
     "db": {
       "host": "keboola.snowflakecomputing.com",
       "username": "svc_migrate",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,8 +68,11 @@ Required if `mode: database`. Ignored if `mode: sapi`.
 |---|---|---|
 | `replicationStrategy` | `standalone` | `standalone` = per-database replication (default, backward compatible). `group` = Snowflake Replication Group, preserves cross-database zero-copy clones to avoid storage inflation. |
 | `replicationGroup.name` | – | Replication group name. Required when `replicationStrategy: group`. Must be the SAME name on the primary (`createReplications`) and secondary (`run`) sides — the caller supplies it. |
-| `replicationGroup.databases` | – | Explicit list of source databases that form the group (used as `ALLOWED_DATABASES` on the primary, and iterated for data copy on the secondary). Required when `replicationStrategy: group`. |
-| `replicationGroup.sourceAccountIdentifier` | – | Source account in `org_name.account_name` format. Run action only. Populated by the orchestrator (`app-project-migrate`). Required when `replicationStrategy: group`. |
+| `replicationGroup.databases` | – | **`createReplications` action only.** Explicit list of source databases that form the group (used as `ALLOWED_DATABASES`). Required there when `replicationStrategy: group`. The `run` action does **not** take this — each run migrates the single project database it resolves from `projectId` the same way standalone does. |
+
+> The source account identifier (`org_name.account_name` format, used by the run action for `CREATE REPLICATION GROUP … AS REPLICA OF …`) is **derived automatically** from `sourceKbcUrl` via the predefined stack mapping in `src/Config.php` — the same mechanism standalone replication uses. It is not a configuration parameter. If `replicationStrategy: group` is used on a stack that has no account identifier in the mapping, the run action fails with a clear error.
+
+> **Same-prefix restriction.** A replication group materializes member databases under their original source names and cannot rename them (unlike standalone, which renames the local replica). To prevent the replicated database from colliding with a destination-owned database, `replicationStrategy: group` is **rejected when the source and target stacks share the same `db_prefix`** in the stack mapping (e.g. `connection.eu-central-1.keboola.com` and `connection.north-europe.azure.keboola.com` both use `KEBOOLA`). Use `standalone` for such stack pairs.
 
 ## Configuration examples
 
@@ -166,9 +169,7 @@ Required if `mode: database`. Ignored if `mode: sapi`.
     "#sourceKbcToken": "xxx",
     "replicationStrategy": "group",
     "replicationGroup": {
-      "name": "MIGRATE_RG_1234",
-      "sourceAccountIdentifier": "MYORG.SOURCEACCT",
-      "databases": ["SAPI_1234", "SAPI_5678"]
+      "name": "MIGRATE_RG_1234"
     },
     "db": {
       "host": "keboola.snowflakecomputing.com",

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -200,10 +200,22 @@ Secondary (run):
 ```
 CREATE REPLICATION GROUP <rg> AS REPLICA OF <sourceOrg>.<sourceAccount>.<rg>;
 ALTER REPLICATION GROUP <rg> REFRESH;
-foreach member database:
-  migrateData(<memberDb>)        ← same TRUNCATE+INSERT loop as standalone
+migrateData(<sourceDb>)          ← single project DB, same TRUNCATE+INSERT as standalone
 DROP REPLICATION GROUP IF EXISTS <rg>;
 ```
+The group spans several databases (for storage efficiency / preserved cross-DB clones),
+but each run migrates only its own project database. The group replicates member databases
+under their original source names, so the run migrates the same `<sourceDb>` the standalone
+path resolves from `projectId` — no database list is needed on the run action.
+
+(`<sourceOrg>.<sourceAccount>` is derived from `sourceKbcUrl` via the predefined
+stack mapping in `src/Config.php` — the same mechanism standalone uses for
+`<region>.<account>` — not supplied as a config parameter)
+
+Because group members keep their source names and cannot be renamed, `<sourceDb>` could
+collide with a destination-owned database of the same name. To prevent that, group mode is
+rejected at config level when source and target stacks share the same `db_prefix`
+(`Config::assertReplicationGroupStacksCompatible()`).
 
 ### migrateData() – detail
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -149,7 +149,19 @@ Snowflake enforces PK uniqueness during `INSERT`. Incremental chunk uploads woul
 
 Database mode uses native Snowflake database replication. Data is not transferred via SAPI – it goes directly Snowflake-to-Snowflake. Significantly faster for large data.
 
-### DatabaseMigrate::migrate() flow
+### Replication strategy: standalone vs group
+
+`replicationStrategy` selects how replication is set up:
+
+- **standalone** (default): each project database is replicated independently
+  (`CREATE DATABASE ... AS REPLICA OF ...`). Cross-database zero-copy clones get
+  materialized on refresh, inflating storage.
+- **group**: a single Snowflake **Replication Group** replicates the listed
+  databases together (`CREATE REPLICATION GROUP ...`), preserving cross-database
+  clone relationships. See
+  https://docs.snowflake.com/en/user-guide/database-replication-considerations
+
+### DatabaseMigrate::migrate() flow (standalone)
 
 ```
 1. targetConnection.useRole('ACCOUNTADMIN')
@@ -170,6 +182,27 @@ Database mode uses native Snowflake database replication. Data is not transferre
 
 6. (if shouldDropReplicaDatabase)
    DROP DATABASE <replicaDb>;
+```
+
+### Replication group flow (replicationStrategy: group)
+
+Primary (createReplications sync action):
+```
+CREATE REPLICATION GROUP <rg>
+  OBJECT_TYPES = DATABASES
+  ALLOWED_DATABASES = <db1>, <db2>, ...
+  ALLOWED_ACCOUNTS = <targetOrg>.<targetAccount>;
+```
+(target org.account read via CURRENT_ORGANIZATION_NAME() / CURRENT_ACCOUNT_NAME();
+"already exists" → ALTER ... SET ALLOWED_DATABASES / ALLOWED_ACCOUNTS)
+
+Secondary (run):
+```
+CREATE REPLICATION GROUP <rg> AS REPLICA OF <sourceOrg>.<sourceAccount>.<rg>;
+ALTER REPLICATION GROUP <rg> REFRESH;
+foreach member database:
+  migrateData(<memberDb>)        ← same TRUNCATE+INSERT loop as standalone
+DROP REPLICATION GROUP IF EXISTS <rg>;
 ```
 
 ### migrateData() – detail
@@ -235,9 +268,15 @@ For BYODB there is one predefined value in `Config.php` (`BYODB_DATABASES`): `so
 Before the first database mode migration between two Snowflake stacks, the source project must enable cross-account replication. Sync action `createReplications` (camelCase) runs:
 
 ```
-DatabaseReplication::run():
-  ALTER DATABASE <sourceDb>
-    ENABLE REPLICATION TO ACCOUNTS <targetAccount>;
+DatabaseReplication::createReplications():
+  standalone:
+    ALTER DATABASE <sourceDb>
+      ENABLE REPLICATION TO ACCOUNTS <targetAccount>;
+  group (replicationStrategy: group):
+    CREATE REPLICATION GROUP <rg>
+      OBJECT_TYPES = DATABASES
+      ALLOWED_DATABASES = <db1>, <db2>, ...
+      ALLOWED_ACCOUNTS = <targetOrg>.<targetAccount>;
 ```
 
 This action must be run in the **source** project using its SAPI token.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -18,6 +18,8 @@ For large GCS tables (sliced + >50 GB), parallel worker processes (`worker-chunk
 
 Uses native Snowflake database replication (`CREATE DATABASE AS REPLICA OF ...`). Significantly faster than sapi mode for large data when migrating between Snowflake stacks.
 
+Database mode supports two replication strategies, selected by `replicationStrategy`: `standalone` (default) replicates each project database independently, while `group` uses a Snowflake **Replication Group** (`CREATE REPLICATION GROUP ...`) to replicate the listed databases together, preserving cross-database zero-copy clones to avoid storage inflation.
+
 ## What is skipped (sapi mode)
 
 - **Sys bucket** tables (`stage === 'sys'`)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -34,7 +34,7 @@ Database mode supports two replication strategies, selected by `replicationStrat
 | `connection.keboola.com` | KEBOOLA | AWS_US_WEST_2 |
 | `connection.eu-central-1.keboola.com` | KEBOOLA | AWS_EU_CENTRAL_1 |
 | `connection.north-europe.azure.keboola.com` | KEBOOLA | AZURE_WESTEUROPE |
-| `connection.europe-west3.gcp.keboola.com` | IK34405 | GCP_EUROPE_WEST4 |
+| `connection.europe-west3.gcp.keboola.com` | PJ41720 | GCP_EUROPE_WEST3 |
 | `connection.us-east4.gcp.keboola.com` | NE35810 | GCP_US_EAST4 |
 | `connection.coates.keboola.cloud` | KEBOOLA | AWS_US_EAST_1 |
 

--- a/src/Component.php
+++ b/src/Component.php
@@ -98,7 +98,7 @@ class Component extends BaseComponent
                     $this->getConfig()->useReplicationGroup(),
                     $this->getConfig()->useReplicationGroup()
                         ? $this->getConfig()->getReplicationGroupName()
-                        : null,
+                        : '',
                     $this->getConfig()->useReplicationGroup()
                         ? $this->getConfig()->getReplicationGroupSourceAccountIdentifier()
                         : '',

--- a/src/Component.php
+++ b/src/Component.php
@@ -42,6 +42,7 @@ class Component extends BaseComponent
                 );
                 break;
             case 'database':
+                $this->getConfig()->assertReplicationGroupStacksCompatible();
                 $verifyToken = $sourceSapiClient->verifyToken();
 
                 $sourceDatabase = sprintf(
@@ -101,9 +102,6 @@ class Component extends BaseComponent
                     $this->getConfig()->useReplicationGroup()
                         ? $this->getConfig()->getReplicationGroupSourceAccountIdentifier()
                         : '',
-                    $this->getConfig()->useReplicationGroup()
-                        ? $this->getConfig()->getReplicationGroupDatabases()
-                        : [],
                 );
                 break;
             default:

--- a/src/Component.php
+++ b/src/Component.php
@@ -94,6 +94,16 @@ class Component extends BaseComponent
                     $replicaDatabase,
                     $targetDatabase,
                     $this->getConfig()->isDryRun(),
+                    $this->getConfig()->useReplicationGroup(),
+                    $this->getConfig()->useReplicationGroup()
+                        ? $this->getConfig()->getReplicationGroupName()
+                        : null,
+                    $this->getConfig()->useReplicationGroup()
+                        ? $this->getConfig()->getReplicationGroupSourceAccountIdentifier()
+                        : '',
+                    $this->getConfig()->useReplicationGroup()
+                        ? $this->getConfig()->getReplicationGroupDatabases()
+                        : [],
                 );
                 break;
             default:

--- a/src/Config.php
+++ b/src/Config.php
@@ -249,6 +249,32 @@ class Config extends BaseConfig
         return (bool) $this->getValue(['parameters', 'migrateData'], true);
     }
 
+    public function getReplicationStrategy(): string
+    {
+        return $this->getStringValue(['parameters', 'replicationStrategy'], 'standalone');
+    }
+
+    public function useReplicationGroup(): bool
+    {
+        return $this->getReplicationStrategy() === 'group';
+    }
+
+    public function getReplicationGroupName(): string
+    {
+        return $this->getStringValue(['parameters', 'replicationGroup', 'name']);
+    }
+
+    public function getReplicationGroupSourceAccountIdentifier(): string
+    {
+        return $this->getStringValue(['parameters', 'replicationGroup', 'sourceAccountIdentifier']);
+    }
+
+    /** @return string[] */
+    public function getReplicationGroupDatabases(): array
+    {
+        return $this->getArrayValue(['parameters', 'replicationGroup', 'databases']);
+    }
+
     public function forcePrimaryKeyNotNull(): bool
     {
         return (bool) $this->getValue(['parameters', 'forcePrimaryKeyNotNull']);

--- a/src/Config.php
+++ b/src/Config.php
@@ -247,7 +247,10 @@ class Config extends BaseConfig
 
     public function shouldDropReplicaDatabase(): bool
     {
-        return (bool) $this->getValue(['parameters', 'replica', 'drop'], true);
+        // A replication group is shared by all per-project runs migrating its member databases, so it
+        // must not be torn down by an individual run — the orchestrator drops it once at the end (or a
+        // run sets "replica.drop": true explicitly). Standalone replicas are per-run and dropped by default.
+        return (bool) $this->getValue(['parameters', 'replica', 'drop'], !$this->useReplicationGroup());
     }
 
     public function shouldMigrateData(): bool

--- a/src/Config.php
+++ b/src/Config.php
@@ -34,9 +34,9 @@ class Config extends BaseConfig
         'connection.europe-west3.gcp.keboola.com' => [
             'db_replica_prefix' => 'GCPEUW3',
             'db_prefix' => 'KBC_EUW3',
-            'account' => 'IK34405',
-            'region' => 'GCP_EUROPE_WEST4',
-            'accountIdentifier' => 'RL74503.COM_KEBOOLA_GCP_EUROPE_WEST3',
+            'account' => 'PJ41720',
+            'region' => 'GCP_EUROPE_WEST3',
+            'accountIdentifier' => 'RL74503.COM_KEBOOLA_GCP_EUROPE_WEST3_2',
         ],
         'connection.us-east4.gcp.keboola.com' => [
             'db_replica_prefix' => 'GCPUSE4',
@@ -303,7 +303,12 @@ class Config extends BaseConfig
             $stack = self::BYODB_DATABASES[$sourceByodb] ?? [];
         } else {
             $url = parse_url($this->getSourceKbcUrl());
-            assert($url && array_key_exists('host', $url));
+            if (!is_array($url) || !isset($url['host'])) {
+                throw new UserException(sprintf(
+                    'Could not parse host from source KBC URL "%s".',
+                    $this->getSourceKbcUrl(),
+                ));
+            }
             $stack = self::STACK_DATABASES[$url['host']] ?? [];
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Keboola\AppProjectMigrateLargeTables;
 
 use Keboola\Component\Config\BaseConfig;
+use Keboola\Component\UserException;
 
 class Config extends BaseConfig
 {
@@ -14,30 +15,35 @@ class Config extends BaseConfig
             'db_prefix' => 'SAPI',
             'account' => 'KEBOOLA',
             'region' => 'AWS_US_WEST_2',
+            'accountIdentifier' => 'RL74503.KEBOOLA_AWS_US_WEST_2',
         ],
         'connection.eu-central-1.keboola.com' => [
             'db_replica_prefix' => 'AWSEU',
             'db_prefix' => 'KEBOOLA',
             'account' => 'KEBOOLA',
             'region' => 'AWS_EU_CENTRAL_1',
+            'accountIdentifier' => 'RL74503.KEBOOLA_AWS_EU_CENTRAL_1',
         ],
         'connection.north-europe.azure.keboola.com' => [
             'db_replica_prefix' => 'AZNE',
             'db_prefix' => 'KEBOOLA',
             'account' => 'KEBOOLA',
             'region' => 'AZURE_WESTEUROPE',
+            'accountIdentifier' => 'RL74503.KEBOOLA_AZURE_WESTEUROPE',
         ],
         'connection.europe-west3.gcp.keboola.com' => [
             'db_replica_prefix' => 'GCPEUW3',
             'db_prefix' => 'KBC_EUW3',
             'account' => 'IK34405',
             'region' => 'GCP_EUROPE_WEST4',
+            'accountIdentifier' => 'RL74503.COM_KEBOOLA_GCP_EUROPE_WEST3',
         ],
         'connection.us-east4.gcp.keboola.com' => [
             'db_replica_prefix' => 'GCPUSE4',
             'db_prefix' => 'KBC_USE4',
             'account' => 'NE35810',
             'region' => 'GCP_US_EAST4',
+            'accountIdentifier' => 'RL74503.COM_KEBOOLA_GCP_US_EAST4',
         ],
         'connection.coates.keboola.cloud' => [
             'db_replica_prefix' => 'COATESAWSUS',
@@ -259,6 +265,29 @@ class Config extends BaseConfig
         return $this->getReplicationStrategy() === 'group';
     }
 
+    /**
+     * A replication group materializes its member databases under their original source names and
+     * cannot rename them. If the source and target stacks share a database prefix, the replicated
+     * member database could collide with a destination-owned database of the same name. Standalone
+     * replication avoids this by renaming the local replica; the group strategy cannot, so it is
+     * rejected for such stack pairs.
+     */
+    public function assertReplicationGroupStacksCompatible(): void
+    {
+        if (!$this->useReplicationGroup()) {
+            return;
+        }
+        if ($this->getSourceDatabasePrefix() === $this->getTargetDatabasePrefix()) {
+            throw new UserException(sprintf(
+                'Replication group migration is not supported between stacks that share the database '
+                . 'prefix "%s": the replicated member databases would collide with the destination\'s '
+                . 'own databases (a replication group cannot rename its members). Use the "standalone" '
+                . 'replication strategy for this stack pair.',
+                $this->getSourceDatabasePrefix(),
+            ));
+        }
+    }
+
     public function getReplicationGroupName(): string
     {
         return $this->getStringValue(['parameters', 'replicationGroup', 'name']);
@@ -266,7 +295,24 @@ class Config extends BaseConfig
 
     public function getReplicationGroupSourceAccountIdentifier(): string
     {
-        return $this->getStringValue(['parameters', 'replicationGroup', 'sourceAccountIdentifier']);
+        if ($this->isSourceByodb()) {
+            $sourceByodb = $this->getStringValue(['parameters', 'sourceByodb']);
+            $stack = self::BYODB_DATABASES[$sourceByodb] ?? [];
+        } else {
+            $url = parse_url($this->getSourceKbcUrl());
+            assert($url && array_key_exists('host', $url));
+            $stack = self::STACK_DATABASES[$url['host']] ?? [];
+        }
+
+        if (empty($stack['accountIdentifier'])) {
+            throw new UserException(sprintf(
+                'Replication group mode is not supported for source stack "%s" '
+                . '(missing Snowflake account identifier).',
+                $this->getSourceKbcUrl(),
+            ));
+        }
+
+        return $stack['accountIdentifier'];
     }
 
     /** @return string[] */

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -39,7 +39,9 @@ class ConfigDefinition extends BaseConfigDefinition
                     ->children()
                         ->booleanNode('create')->defaultTrue()->end()
                         ->booleanNode('refresh')->defaultTrue()->end()
-                        ->booleanNode('drop')->defaultTrue()->end()
+                        // No default: the default depends on replicationStrategy and is resolved in
+                        // Config::shouldDropReplicaDatabase() (true for standalone, false for group).
+                        ->booleanNode('drop')->end()
                     ->end()
                 ->end()
                 ->enumNode('replicationStrategy')

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -49,8 +49,6 @@ class ConfigDefinition extends BaseConfigDefinition
                 ->arrayNode('replicationGroup')
                     ->children()
                         ->scalarNode('name')->cannotBeEmpty()->end()
-                        ->scalarNode('sourceAccountIdentifier')->cannotBeEmpty()->end()
-                        ->arrayNode('databases')->prototype('scalar')->end()->end()
                     ->end()
                 ->end()
                 ->arrayNode('db')
@@ -88,18 +86,6 @@ class ConfigDefinition extends BaseConfigDefinition
                 if (empty($v['replicationGroup']['name'])) {
                     throw new InvalidConfigurationException(
                         'When "replicationStrategy" is "group", "replicationGroup.name" must be set.',
-                    );
-                }
-                if (empty($v['replicationGroup']['sourceAccountIdentifier'])) {
-                    throw new InvalidConfigurationException(
-                        'When "replicationStrategy" is "group", ' .
-                        '"replicationGroup.sourceAccountIdentifier" must be set.',
-                    );
-                }
-                if (empty($v['replicationGroup']['databases'])) {
-                    throw new InvalidConfigurationException(
-                        'When "replicationStrategy" is "group", ' .
-                        '"replicationGroup.databases" must not be empty.',
                     );
                 }
                 return $v;

--- a/src/Configuration/ConfigDefinition.php
+++ b/src/Configuration/ConfigDefinition.php
@@ -42,6 +42,17 @@ class ConfigDefinition extends BaseConfigDefinition
                         ->booleanNode('drop')->defaultTrue()->end()
                     ->end()
                 ->end()
+                ->enumNode('replicationStrategy')
+                    ->values(['standalone', 'group'])
+                    ->defaultValue('standalone')
+                ->end()
+                ->arrayNode('replicationGroup')
+                    ->children()
+                        ->scalarNode('name')->cannotBeEmpty()->end()
+                        ->scalarNode('sourceAccountIdentifier')->cannotBeEmpty()->end()
+                        ->arrayNode('databases')->prototype('scalar')->end()->end()
+                    ->end()
+                ->end()
                 ->arrayNode('db')
                     ->validate()->always(function ($v) {
                         if (!empty($v['#privateKey']) && !empty($v['#password'])) {
@@ -68,6 +79,33 @@ class ConfigDefinition extends BaseConfigDefinition
             ->end()
         ;
         // @formatter:on
+        $parametersNode
+            ->validate()
+            ->always(function ($v) {
+                if (($v['replicationStrategy'] ?? 'standalone') !== 'group') {
+                    return $v;
+                }
+                if (empty($v['replicationGroup']['name'])) {
+                    throw new InvalidConfigurationException(
+                        'When "replicationStrategy" is "group", "replicationGroup.name" must be set.',
+                    );
+                }
+                if (empty($v['replicationGroup']['sourceAccountIdentifier'])) {
+                    throw new InvalidConfigurationException(
+                        'When "replicationStrategy" is "group", ' .
+                        '"replicationGroup.sourceAccountIdentifier" must be set.',
+                    );
+                }
+                if (empty($v['replicationGroup']['databases'])) {
+                    throw new InvalidConfigurationException(
+                        'When "replicationStrategy" is "group", ' .
+                        '"replicationGroup.databases" must not be empty.',
+                    );
+                }
+                return $v;
+            })
+            ->end()
+        ;
         return $parametersNode;
     }
 }

--- a/src/Configuration/CreateReplicationsConfigDefinition.php
+++ b/src/Configuration/CreateReplicationsConfigDefinition.php
@@ -36,12 +36,12 @@ class CreateReplicationsConfigDefinition extends BaseConfigDefinition
                 ->end()
             ->end()
             ->validate()->always(function ($v) {
-                if (!empty($v['#privateKey']) && !empty($v['#password'])) {
+                if (!empty($v['#sourcePrivateKey']) && !empty($v['#sourcePassword'])) {
                     throw new InvalidConfigurationException(
                         'You can use either privateKey or password, not both.',
                     );
                 }
-                if (empty($v['#privateKey']) && empty($v['#password'])) {
+                if (empty($v['#sourcePrivateKey']) && empty($v['#sourcePassword'])) {
                     throw new InvalidConfigurationException(
                         'You must provide either privateKey or password.',
                     );

--- a/src/Configuration/CreateReplicationsConfigDefinition.php
+++ b/src/Configuration/CreateReplicationsConfigDefinition.php
@@ -24,6 +24,16 @@ class CreateReplicationsConfigDefinition extends BaseConfigDefinition
                 ->scalarNode('#sourcePrivateKey')->cannotBeEmpty()->end()
                 ->integerNode('projectIdFrom')->isRequired()->end()
                 ->integerNode('projectIdTo')->isRequired()->end()
+                ->enumNode('replicationStrategy')
+                    ->values(['standalone', 'group'])
+                    ->defaultValue('standalone')
+                ->end()
+                ->arrayNode('replicationGroup')
+                    ->children()
+                        ->scalarNode('name')->cannotBeEmpty()->end()
+                        ->arrayNode('databases')->prototype('scalar')->end()->end()
+                    ->end()
+                ->end()
             ->end()
             ->validate()->always(function ($v) {
                 if (!empty($v['#privateKey']) && !empty($v['#password'])) {
@@ -35,6 +45,19 @@ class CreateReplicationsConfigDefinition extends BaseConfigDefinition
                     throw new InvalidConfigurationException(
                         'You must provide either privateKey or password.',
                     );
+                }
+                if (($v['replicationStrategy'] ?? 'standalone') === 'group') {
+                    if (empty($v['replicationGroup']['name'])) {
+                        throw new InvalidConfigurationException(
+                            'When "replicationStrategy" is "group", "replicationGroup.name" must be set.',
+                        );
+                    }
+                    if (empty($v['replicationGroup']['databases'])) {
+                        throw new InvalidConfigurationException(
+                            'When "replicationStrategy" is "group", ' .
+                            '"replicationGroup.databases" must not be empty.',
+                        );
+                    }
                 }
                 return $v;
             })->end()

--- a/src/Snowflake/Connection.php
+++ b/src/Snowflake/Connection.php
@@ -13,6 +13,10 @@ class Connection extends AdapterConnection
 
     private ?string $account = null;
 
+    private ?string $orgName = null;
+
+    private ?string $accountName = null;
+
     private string $user;
 
     public function __construct(array $options)
@@ -46,6 +50,26 @@ class Connection extends AdapterConnection
             $this->account = $this->fetchAll('SELECT CURRENT_ACCOUNT() AS "account";')[0]['account'];
         }
         return $this->account;
+    }
+
+    public function getOrgName(): string
+    {
+        if (is_null($this->orgName)) {
+            $this->orgName = $this->fetchAll(
+                'SELECT CURRENT_ORGANIZATION_NAME() AS "orgName";',
+            )[0]['orgName'];
+        }
+        return $this->orgName;
+    }
+
+    public function getAccountName(): string
+    {
+        if (is_null($this->accountName)) {
+            $this->accountName = $this->fetchAll(
+                'SELECT CURRENT_ACCOUNT_NAME() AS "accountName";',
+            )[0]['accountName'];
+        }
+        return $this->accountName;
     }
 
     public function grantRoleToMigrateUser(string $tableRole): void

--- a/src/Strategy/DatabaseMigrate.php
+++ b/src/Strategy/DatabaseMigrate.php
@@ -32,7 +32,7 @@ class DatabaseMigrate implements MigrateInterface
         private readonly string $targetDatabase,
         private readonly bool $dryRun = false,
         private readonly bool $useReplicationGroup = false,
-        private readonly ?string $replicationGroupName = null,
+        private readonly string $replicationGroupName = '',
         private readonly string $replicationGroupSourceAccountIdentifier = '',
     ) {
         $this->storageModifier = new StorageModifier($this->targetSapiClient);
@@ -70,7 +70,7 @@ class DatabaseMigrate implements MigrateInterface
 
     private function migrateViaReplicationGroup(Config $config): void
     {
-        if ($this->replicationGroupName === null) {
+        if ($this->replicationGroupName === '') {
             throw new RuntimeException(
                 'Replication group name must be set when replication group mode is enabled.',
             );

--- a/src/Strategy/DatabaseMigrate.php
+++ b/src/Strategy/DatabaseMigrate.php
@@ -72,7 +72,11 @@ class DatabaseMigrate implements MigrateInterface
 
     private function migrateViaReplicationGroup(Config $config): void
     {
-        assert($this->replicationGroupName !== null);
+        if ($this->replicationGroupName === null) {
+            throw new RuntimeException(
+                'Replication group name must be set when replication group mode is enabled.',
+            );
+        }
         $group = new ReplicationGroup($this->replicationGroupName, $this->replicationGroupDatabases);
 
         $currentRole = $this->targetConnection->getCurrentRole();

--- a/src/Strategy/DatabaseMigrate.php
+++ b/src/Strategy/DatabaseMigrate.php
@@ -34,8 +34,6 @@ class DatabaseMigrate implements MigrateInterface
         private readonly bool $useReplicationGroup = false,
         private readonly ?string $replicationGroupName = null,
         private readonly string $replicationGroupSourceAccountIdentifier = '',
-        /** @var string[] */
-        private readonly array $replicationGroupDatabases = [],
     ) {
         $this->storageModifier = new StorageModifier($this->targetSapiClient);
     }
@@ -77,7 +75,7 @@ class DatabaseMigrate implements MigrateInterface
                 'Replication group name must be set when replication group mode is enabled.',
             );
         }
-        $group = new ReplicationGroup($this->replicationGroupName, $this->replicationGroupDatabases);
+        $group = new ReplicationGroup($this->replicationGroupName);
 
         $currentRole = $this->targetConnection->getCurrentRole();
         $this->targetConnection->useRole('ACCOUNTADMIN');
@@ -89,10 +87,14 @@ class DatabaseMigrate implements MigrateInterface
         }
         $this->targetConnection->useRole($currentRole);
 
+        // The replication group spans several databases for storage efficiency, but each run migrates
+        // a single project database. Unlike standalone — which copies from a renamed local replica
+        // (<prefix>_<id>_REPLICA) — a replication group materializes its members under their original
+        // source names and cannot rename them, so we read from $this->sourceDatabase directly. Group
+        // mode is rejected at config level when source and target stacks share a database prefix, so
+        // this name cannot collide with a destination-owned database.
         if ($config->shouldMigrateData()) {
-            foreach ($group->getDatabases() as $replicaDatabase) {
-                $this->migrateData($config, $replicaDatabase);
-            }
+            $this->migrateData($config, $this->sourceDatabase);
         }
 
         if ($config->shouldDropReplicaDatabase()) {

--- a/src/Strategy/DatabaseMigrate.php
+++ b/src/Strategy/DatabaseMigrate.php
@@ -31,11 +31,25 @@ class DatabaseMigrate implements MigrateInterface
         private readonly string $replicaDatabase,
         private readonly string $targetDatabase,
         private readonly bool $dryRun = false,
+        private readonly bool $useReplicationGroup = false,
+        private readonly ?string $replicationGroupName = null,
+        private readonly string $replicationGroupSourceAccountIdentifier = '',
+        /** @var string[] */
+        private readonly array $replicationGroupDatabases = [],
     ) {
         $this->storageModifier = new StorageModifier($this->targetSapiClient);
     }
 
     public function migrate(Config $config): void
+    {
+        if ($this->useReplicationGroup) {
+            $this->migrateViaReplicationGroup($config);
+            return;
+        }
+        $this->migrateViaStandaloneReplica($config);
+    }
+
+    private function migrateViaStandaloneReplica(Config $config): void
     {
         $currentRole = $this->targetConnection->getCurrentRole();
         $this->targetConnection->useRole('ACCOUNTADMIN');
@@ -48,15 +62,80 @@ class DatabaseMigrate implements MigrateInterface
         $this->targetConnection->useRole($currentRole);
 
         if ($config->shouldMigrateData()) {
-            $this->migrateData($config);
+            $this->migrateData($config, $this->replicaDatabase);
         }
 
         if ($config->shouldDropReplicaDatabase()) {
-            $this->dropReplicaDatabase();
+            $this->dropReplicaDatabase($this->replicaDatabase);
         }
     }
 
-    public function migrateData(Config $config): void
+    private function migrateViaReplicationGroup(Config $config): void
+    {
+        assert($this->replicationGroupName !== null);
+        $group = new ReplicationGroup($this->replicationGroupName, $this->replicationGroupDatabases);
+
+        $currentRole = $this->targetConnection->getCurrentRole();
+        $this->targetConnection->useRole('ACCOUNTADMIN');
+        if ($config->shouldCreateReplicaDatabase()) {
+            $this->createReplicationGroupReplica($group);
+        }
+        if ($config->shouldRefreshReplicaDatabase()) {
+            $this->refreshReplicationGroup($config, $group);
+        }
+        $this->targetConnection->useRole($currentRole);
+
+        if ($config->shouldMigrateData()) {
+            foreach ($group->getDatabases() as $replicaDatabase) {
+                $this->migrateData($config, $replicaDatabase);
+            }
+        }
+
+        if ($config->shouldDropReplicaDatabase()) {
+            $this->dropReplicationGroup($group);
+        }
+    }
+
+    private function createReplicationGroupReplica(ReplicationGroup $group): void
+    {
+        $this->logger->info(sprintf(
+            'Creating replication group replica "%s" as replica of %s',
+            $this->replicationGroupName,
+            $this->replicationGroupSourceAccountIdentifier,
+        ));
+        try {
+            $this->targetConnection->query(
+                $group->createSecondarySql($this->replicationGroupSourceAccountIdentifier),
+            );
+        } catch (RuntimeException $e) {
+            if (!str_contains($e->getMessage(), 'already exists')) {
+                throw $e;
+            }
+            $this->logger->info(sprintf(
+                'Replication group replica "%s" already exists, skipping create.',
+                $this->replicationGroupName,
+            ));
+        }
+    }
+
+    private function refreshReplicationGroup(Config $config, ReplicationGroup $group): void
+    {
+        $this->targetConnection->query(sprintf(
+            'USE WAREHOUSE %s',
+            QueryBuilder::quoteIdentifier($config->getTargetWarehouse()),
+        ));
+        $this->logger->info(sprintf('Refreshing replication group "%s"', $this->replicationGroupName));
+        $this->targetConnection->query($group->refreshSql());
+    }
+
+    private function dropReplicationGroup(ReplicationGroup $group): void
+    {
+        $this->targetConnection->useRole('ACCOUNTADMIN');
+        $this->logger->info(sprintf('Dropping replication group "%s"', $this->replicationGroupName));
+        $this->targetConnection->query($group->dropSql());
+    }
+
+    public function migrateData(Config $config, string $replicaDatabase): void
     {
         $databaseRole = $this->getSourceRole(
             $this->targetConnection,
@@ -91,7 +170,7 @@ class DatabaseMigrate implements MigrateInterface
         $this->targetConnection->useRole('ACCOUNTADMIN');
         $schemas = $this->targetConnection->fetchAll(sprintf(
             'SHOW SCHEMAS IN DATABASE %s;',
-            QueryBuilder::quoteIdentifier($this->replicaDatabase),
+            QueryBuilder::quoteIdentifier($replicaDatabase),
         ));
         $this->targetConnection->useRole($currentRole);
 
@@ -119,18 +198,18 @@ class DatabaseMigrate implements MigrateInterface
                 }
             }
 
-            $this->migrateSchema($config->getMigrateTables(), $schemaName);
+            $this->migrateSchema($config->getMigrateTables(), $schemaName, $replicaDatabase);
         }
     }
 
-    private function migrateSchema(array $tablesWhiteList, string $schemaName): void
+    private function migrateSchema(array $tablesWhiteList, string $schemaName, string $replicaDatabase): void
     {
         $this->logger->info(sprintf('Migrating schema %s', $schemaName));
         $currentRole = $this->targetConnection->getCurrentRole();
         $this->targetConnection->useRole('ACCOUNTADMIN');
         $tables = $this->targetConnection->fetchAll(sprintf(
             'SHOW TABLES IN SCHEMA %s.%s;',
-            QueryBuilder::quoteIdentifier($this->replicaDatabase),
+            QueryBuilder::quoteIdentifier($replicaDatabase),
             QueryBuilder::quoteIdentifier($schemaName),
         ));
         $this->targetConnection->useRole($currentRole);
@@ -153,7 +232,7 @@ class DatabaseMigrate implements MigrateInterface
                 );
             }
 
-            $this->migrateTable($schemaName, $table['name']);
+            $this->migrateTable($schemaName, $table['name'], $replicaDatabase);
         }
 
         if ($this->dryRun === false) {
@@ -164,7 +243,7 @@ class DatabaseMigrate implements MigrateInterface
         }
     }
 
-    private function migrateTable(string $schemaName, string $tableName): void
+    private function migrateTable(string $schemaName, string $tableName, string $replicaDatabase): void
     {
         $this->logger->info(sprintf('Migrating table %s.%s', $schemaName, $tableName));
         $tableRole = $this->getSourceRole(
@@ -181,7 +260,7 @@ class DatabaseMigrate implements MigrateInterface
         }
 
         $this->targetConnection->grantPrivilegesToReplicaDatabase(
-            $this->replicaDatabase,
+            $replicaDatabase,
             $tableRole,
         );
 
@@ -190,7 +269,7 @@ class DatabaseMigrate implements MigrateInterface
         $compareTimestamp = $this->compareTableMaxTimestamp(
             'ACCOUNTADMIN',
             $tableRole,
-            $this->replicaDatabase,
+            $replicaDatabase,
             $this->targetDatabase,
             $schemaName,
             $tableName,
@@ -216,7 +295,7 @@ class DatabaseMigrate implements MigrateInterface
                 QueryBuilder::quoteIdentifier($tableName),
                 implode(', ', array_map(fn($v) => QueryBuilder::quoteIdentifier($v), $columns)),
                 implode(', ', array_map(fn($v) => QueryBuilder::quoteIdentifier($v), $columns)),
-                QueryBuilder::quoteIdentifier($this->replicaDatabase),
+                QueryBuilder::quoteIdentifier($replicaDatabase),
                 QueryBuilder::quoteIdentifier($schemaName),
                 QueryBuilder::quoteIdentifier($tableName),
             ));
@@ -306,12 +385,12 @@ class DatabaseMigrate implements MigrateInterface
         ));
     }
 
-    private function dropReplicaDatabase(): void
+    private function dropReplicaDatabase(string $replicaDatabase): void
     {
         $this->targetConnection->useRole('ACCOUNTADMIN');
         $this->targetConnection->query(sprintf(
             'DROP DATABASE %s;',
-            QueryBuilder::quoteIdentifier($this->replicaDatabase),
+            QueryBuilder::quoteIdentifier($replicaDatabase),
         ));
     }
 

--- a/src/Strategy/DatabaseMigrate.php
+++ b/src/Strategy/DatabaseMigrate.php
@@ -75,6 +75,12 @@ class DatabaseMigrate implements MigrateInterface
                 'Replication group name must be set when replication group mode is enabled.',
             );
         }
+        if ($this->replicationGroupSourceAccountIdentifier === '') {
+            throw new RuntimeException(
+                'Replication group source account identifier must be set when replication group mode '
+                . 'is enabled.',
+            );
+        }
         $group = new ReplicationGroup($this->replicationGroupName);
 
         $currentRole = $this->targetConnection->getCurrentRole();

--- a/src/Strategy/DatabaseReplication.php
+++ b/src/Strategy/DatabaseReplication.php
@@ -6,6 +6,7 @@ namespace Keboola\AppProjectMigrateLargeTables\Strategy;
 
 use Keboola\AppProjectMigrateLargeTables\Config;
 use Keboola\AppProjectMigrateLargeTables\Snowflake\Connection;
+use Keboola\SnowflakeDbAdapter\Exception\RuntimeException;
 use Keboola\SnowflakeDbAdapter\QueryBuilder;
 use Psr\Log\LoggerInterface;
 
@@ -23,6 +24,22 @@ class DatabaseReplication
         int $fromProjectId,
         int $toProjectId,
     ): void {
+        if ($config->useReplicationGroup()) {
+            $this->createReplicationGroup(
+                $config->getReplicationGroupName(),
+                $config->getReplicationGroupDatabases(),
+            );
+            return;
+        }
+
+        $this->createStandaloneReplications($config, $fromProjectId, $toProjectId);
+    }
+
+    private function createStandaloneReplications(
+        Config $config,
+        int $fromProjectId,
+        int $toProjectId,
+    ): void {
         $databases = array_map(fn($v) => $v['name'], $this->sourceConnection->fetchAll('SHOW DATABASES;'));
         for ($i = $fromProjectId; $i <= $toProjectId; $i++) {
             $sourceDatabase = sprintf('%s_%s', $config->getSourceDatabasePrefix(), $i);
@@ -31,6 +48,48 @@ class DatabaseReplication
             }
             $this->createReplication($sourceDatabase);
         }
+    }
+
+    /**
+     * @param string[] $databases
+     */
+    private function createReplicationGroup(string $name, array $databases): void
+    {
+        $group = new ReplicationGroup($name, $databases);
+
+        $targetAccountIdentifier = sprintf(
+            '%s.%s',
+            $this->targetConnection->getOrgName(),
+            $this->targetConnection->getAccountName(),
+        );
+
+        $this->logger->info(sprintf(
+            'Creating replication group "%s" for databases: %s -> account %s',
+            $name,
+            implode(', ', $databases),
+            $targetAccountIdentifier,
+        ));
+
+        try {
+            $this->sourceConnection->query($group->createPrimarySql($targetAccountIdentifier));
+        } catch (RuntimeException $e) {
+            if (!str_contains($e->getMessage(), 'already exists')) {
+                throw $e;
+            }
+            $this->logger->info(sprintf(
+                'Replication group "%s" already exists, altering members instead.',
+                $name,
+            ));
+            $this->alterReplicationGroupMembers($group, $targetAccountIdentifier);
+        }
+    }
+
+    private function alterReplicationGroupMembers(
+        ReplicationGroup $group,
+        string $targetAccountIdentifier,
+    ): void {
+        $this->sourceConnection->query($group->alterAllowedDatabasesSql());
+        $this->sourceConnection->query($group->alterAllowedAccountsSql($targetAccountIdentifier));
     }
 
     public function createReplication(string $sourceDatabase): void

--- a/src/Strategy/ReplicationGroup.php
+++ b/src/Strategy/ReplicationGroup.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AppProjectMigrateLargeTables\Strategy;
+
+use Keboola\SnowflakeDbAdapter\QueryBuilder;
+
+class ReplicationGroup
+{
+    /**
+     * @param string[] $databases
+     */
+    public function __construct(
+        private readonly string $name,
+        private readonly array $databases,
+    ) {
+    }
+
+    /** @return string[] */
+    public function getDatabases(): array
+    {
+        return $this->databases;
+    }
+
+    public function createPrimarySql(string $targetAccountIdentifier): string
+    {
+        return sprintf(
+            'CREATE REPLICATION GROUP %s OBJECT_TYPES = DATABASES '
+            . 'ALLOWED_DATABASES = %s ALLOWED_ACCOUNTS = %s;',
+            QueryBuilder::quoteIdentifier($this->name),
+            $this->quotedDatabaseList(),
+            $targetAccountIdentifier,
+        );
+    }
+
+    public function createSecondarySql(string $sourceAccountIdentifier): string
+    {
+        return sprintf(
+            'CREATE REPLICATION GROUP %s AS REPLICA OF %s.%s;',
+            QueryBuilder::quoteIdentifier($this->name),
+            $sourceAccountIdentifier,
+            QueryBuilder::quoteIdentifier($this->name),
+        );
+    }
+
+    public function refreshSql(): string
+    {
+        return sprintf(
+            'ALTER REPLICATION GROUP %s REFRESH;',
+            QueryBuilder::quoteIdentifier($this->name),
+        );
+    }
+
+    public function dropSql(): string
+    {
+        return sprintf(
+            'DROP REPLICATION GROUP IF EXISTS %s;',
+            QueryBuilder::quoteIdentifier($this->name),
+        );
+    }
+
+    public function alterAllowedDatabasesSql(): string
+    {
+        return sprintf(
+            'ALTER REPLICATION GROUP %s SET ALLOWED_DATABASES = %s;',
+            QueryBuilder::quoteIdentifier($this->name),
+            $this->quotedDatabaseList(),
+        );
+    }
+
+    public function alterAllowedAccountsSql(string $targetAccountIdentifier): string
+    {
+        return sprintf(
+            'ALTER REPLICATION GROUP %s SET ALLOWED_ACCOUNTS = %s;',
+            QueryBuilder::quoteIdentifier($this->name),
+            $targetAccountIdentifier,
+        );
+    }
+
+    private function quotedDatabaseList(): string
+    {
+        return implode(
+            ', ',
+            array_map(fn(string $db) => QueryBuilder::quoteIdentifier($db), $this->databases),
+        );
+    }
+}

--- a/src/Strategy/ReplicationGroup.php
+++ b/src/Strategy/ReplicationGroup.php
@@ -9,11 +9,12 @@ use Keboola\SnowflakeDbAdapter\QueryBuilder;
 class ReplicationGroup
 {
     /**
-     * @param string[] $databases
+     * @param string[] $databases Only needed on the primary side (ALLOWED_DATABASES);
+     *                            the secondary side replicates the whole group by name.
      */
     public function __construct(
         private readonly string $name,
-        private readonly array $databases,
+        private readonly array $databases = [],
     ) {
     }
 

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -282,4 +282,45 @@ class ConfigTest extends TestCase
 
         self::assertFalse($config->useReplicationGroup());
     }
+
+    public function testShouldDropReplicaDatabaseDefaultsTrueForStandalone(): void
+    {
+        $config = $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+        ]);
+
+        self::assertTrue($config->shouldDropReplicaDatabase());
+    }
+
+    public function testShouldDropReplicaDatabaseDefaultsFalseForGroup(): void
+    {
+        $config = $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+            'replicationStrategy' => 'group',
+            'replicationGroup' => [
+                'name' => 'MIGRATE_RG_1234',
+            ],
+        ]);
+
+        self::assertFalse($config->shouldDropReplicaDatabase());
+    }
+
+    public function testShouldDropReplicaDatabaseRespectsExplicitValueInGroup(): void
+    {
+        $config = $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+            'replicationStrategy' => 'group',
+            'replicationGroup' => [
+                'name' => 'MIGRATE_RG_1234',
+            ],
+            'replica' => [
+                'drop' => true,
+            ],
+        ]);
+
+        self::assertTrue($config->shouldDropReplicaDatabase());
+    }
 }

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -114,4 +114,49 @@ class ConfigTest extends TestCase
         ]);
         self::assertTrue($config->forcePrimaryKeyNotNull());
     }
+
+    public function testReplicationStrategyDefaultsToStandalone(): void
+    {
+        $config = $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+        ]);
+
+        self::assertSame('standalone', $config->getReplicationStrategy());
+        self::assertFalse($config->useReplicationGroup());
+    }
+
+    public function testReplicationGroupConfig(): void
+    {
+        $config = $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+            'replicationStrategy' => 'group',
+            'replicationGroup' => [
+                'name' => 'MIGRATE_RG_1234',
+                'sourceAccountIdentifier' => 'MYORG.SOURCEACCT',
+                'databases' => ['SAPI_1234', 'SAPI_5678'],
+            ],
+        ]);
+
+        self::assertSame('group', $config->getReplicationStrategy());
+        self::assertTrue($config->useReplicationGroup());
+        self::assertSame('MIGRATE_RG_1234', $config->getReplicationGroupName());
+        self::assertSame('MYORG.SOURCEACCT', $config->getReplicationGroupSourceAccountIdentifier());
+        self::assertSame(['SAPI_1234', 'SAPI_5678'], $config->getReplicationGroupDatabases());
+    }
+
+    public function testReplicationGroupRequiresNameWhenStrategyGroup(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage(
+            'When "replicationStrategy" is "group", "replicationGroup.name" must be set.',
+        );
+
+        $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+            'replicationStrategy' => 'group',
+        ]);
+    }
 }

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -6,11 +6,18 @@ namespace Keboola\AppProjectMigrateLargeTables\Tests;
 
 use Keboola\AppProjectMigrateLargeTables\Config;
 use Keboola\AppProjectMigrateLargeTables\Configuration\ConfigDefinition;
+use Keboola\Component\UserException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 class ConfigTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        putenv('KBC_URL');
+        parent::tearDown();
+    }
+
     private function buildConfig(array $parameters): Config
     {
         return new Config(
@@ -134,16 +141,78 @@ class ConfigTest extends TestCase
             'replicationStrategy' => 'group',
             'replicationGroup' => [
                 'name' => 'MIGRATE_RG_1234',
-                'sourceAccountIdentifier' => 'MYORG.SOURCEACCT',
-                'databases' => ['SAPI_1234', 'SAPI_5678'],
             ],
         ]);
 
         self::assertSame('group', $config->getReplicationStrategy());
         self::assertTrue($config->useReplicationGroup());
         self::assertSame('MIGRATE_RG_1234', $config->getReplicationGroupName());
-        self::assertSame('MYORG.SOURCEACCT', $config->getReplicationGroupSourceAccountIdentifier());
-        self::assertSame(['SAPI_1234', 'SAPI_5678'], $config->getReplicationGroupDatabases());
+    }
+
+    /**
+     * @dataProvider sourceAccountIdentifierProvider
+     */
+    public function testSourceAccountIdentifierDerivedFromStack(string $sourceKbcUrl, string $expected): void
+    {
+        $config = $this->buildConfig([
+            'sourceKbcUrl' => $sourceKbcUrl,
+            '#sourceKbcToken' => 'token',
+            'replicationStrategy' => 'group',
+            'replicationGroup' => [
+                'name' => 'MIGRATE_RG_1234',
+            ],
+        ]);
+
+        self::assertSame($expected, $config->getReplicationGroupSourceAccountIdentifier());
+    }
+
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public function sourceAccountIdentifierProvider(): array
+    {
+        return [
+            'aws-us-west' => [
+                'https://connection.keboola.com',
+                'RL74503.KEBOOLA_AWS_US_WEST_2',
+            ],
+            'aws-eu-central' => [
+                'https://connection.eu-central-1.keboola.com',
+                'RL74503.KEBOOLA_AWS_EU_CENTRAL_1',
+            ],
+            'azure-north-europe' => [
+                'https://connection.north-europe.azure.keboola.com',
+                'RL74503.KEBOOLA_AZURE_WESTEUROPE',
+            ],
+            'gcp-europe-west3' => [
+                'https://connection.europe-west3.gcp.keboola.com',
+                'RL74503.COM_KEBOOLA_GCP_EUROPE_WEST3',
+            ],
+            'gcp-us-east4' => [
+                'https://connection.us-east4.gcp.keboola.com',
+                'RL74503.COM_KEBOOLA_GCP_US_EAST4',
+            ],
+        ];
+    }
+
+    public function testSourceAccountIdentifierThrowsForUnsupportedStack(): void
+    {
+        $config = $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.coates.keboola.cloud',
+            '#sourceKbcToken' => 'token',
+            'replicationStrategy' => 'group',
+            'replicationGroup' => [
+                'name' => 'MIGRATE_RG_1234',
+            ],
+        ]);
+
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage(
+            'Replication group mode is not supported for source stack '
+            . '"https://connection.coates.keboola.cloud"',
+        );
+
+        $config->getReplicationGroupSourceAccountIdentifier();
     }
 
     public function testReplicationGroupRequiresNameWhenStrategyGroup(): void
@@ -158,5 +227,59 @@ class ConfigTest extends TestCase
             '#sourceKbcToken' => 'token',
             'replicationStrategy' => 'group',
         ]);
+    }
+
+    public function testReplicationGroupBlockedForStacksSharingDatabasePrefix(): void
+    {
+        // Both connection.eu-central-1 and connection.north-europe.azure use the "KEBOOLA" db prefix.
+        putenv('KBC_URL=https://connection.north-europe.azure.keboola.com');
+        $config = $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.eu-central-1.keboola.com',
+            '#sourceKbcToken' => 'token',
+            'replicationStrategy' => 'group',
+            'replicationGroup' => [
+                'name' => 'MIGRATE_RG_1234',
+            ],
+        ]);
+
+        $this->expectException(UserException::class);
+        $this->expectExceptionMessage(
+            'Replication group migration is not supported between stacks that share the database '
+            . 'prefix "KEBOOLA"',
+        );
+
+        $config->assertReplicationGroupStacksCompatible();
+    }
+
+    public function testReplicationGroupAllowedForStacksWithDifferentDatabasePrefix(): void
+    {
+        // Source connection.keboola.com uses "SAPI", target north-europe uses "KEBOOLA".
+        putenv('KBC_URL=https://connection.north-europe.azure.keboola.com');
+        $config = $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            '#sourceKbcToken' => 'token',
+            'replicationStrategy' => 'group',
+            'replicationGroup' => [
+                'name' => 'MIGRATE_RG_1234',
+            ],
+        ]);
+
+        $config->assertReplicationGroupStacksCompatible();
+
+        self::assertTrue($config->useReplicationGroup());
+    }
+
+    public function testReplicationGroupStackCheckSkippedForStandalone(): void
+    {
+        // Same prefix on both sides, but standalone strategy must not be blocked.
+        putenv('KBC_URL=https://connection.eu-central-1.keboola.com');
+        $config = $this->buildConfig([
+            'sourceKbcUrl' => 'https://connection.eu-central-1.keboola.com',
+            '#sourceKbcToken' => 'token',
+        ]);
+
+        $config->assertReplicationGroupStacksCompatible();
+
+        self::assertFalse($config->useReplicationGroup());
     }
 }

--- a/tests/phpunit/ConfigTest.php
+++ b/tests/phpunit/ConfigTest.php
@@ -186,7 +186,7 @@ class ConfigTest extends TestCase
             ],
             'gcp-europe-west3' => [
                 'https://connection.europe-west3.gcp.keboola.com',
-                'RL74503.COM_KEBOOLA_GCP_EUROPE_WEST3',
+                'RL74503.COM_KEBOOLA_GCP_EUROPE_WEST3_2',
             ],
             'gcp-us-east4' => [
                 'https://connection.us-east4.gcp.keboola.com',

--- a/tests/phpunit/CreateReplicationsConfigDefinitionTest.php
+++ b/tests/phpunit/CreateReplicationsConfigDefinitionTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AppProjectMigrateLargeTables\Tests;
+
+use Keboola\AppProjectMigrateLargeTables\Config;
+use Keboola\AppProjectMigrateLargeTables\Configuration\CreateReplicationsConfigDefinition;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+
+class CreateReplicationsConfigDefinitionTest extends TestCase
+{
+    private function buildConfig(array $parameters): Config
+    {
+        return new Config(
+            ['parameters' => $parameters],
+            new CreateReplicationsConfigDefinition(),
+        );
+    }
+
+    private function baseParameters(): array
+    {
+        return [
+            'sourceKbcUrl' => 'https://connection.keboola.com',
+            'sourceHost' => 'source.snowflakecomputing.com',
+            'sourceUsername' => 'MIGRATE_USER',
+            '#sourcePassword' => 'secret',
+            'projectIdFrom' => 1234,
+            'projectIdTo' => 5678,
+        ];
+    }
+
+    public function testValidConfigWithPassword(): void
+    {
+        $config = $this->buildConfig($this->baseParameters());
+
+        self::assertSame('standalone', $config->getParameters()['replicationStrategy']);
+    }
+
+    public function testValidConfigWithPrivateKey(): void
+    {
+        $parameters = $this->baseParameters();
+        unset($parameters['#sourcePassword']);
+        $parameters['#sourcePrivateKey'] = 'private-key';
+
+        $config = $this->buildConfig($parameters);
+
+        self::assertSame('private-key', $config->getParameters()['#sourcePrivateKey']);
+    }
+
+    public function testReplicationStrategyDefaultsToStandalone(): void
+    {
+        $config = $this->buildConfig($this->baseParameters());
+
+        self::assertSame('standalone', $config->getParameters()['replicationStrategy']);
+    }
+
+    public function testCredentialsAreRequired(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You must provide either privateKey or password.');
+
+        $parameters = $this->baseParameters();
+        unset($parameters['#sourcePassword']);
+
+        $this->buildConfig($parameters);
+    }
+
+    public function testCannotProvideBothCredentials(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You can use either privateKey or password, not both.');
+
+        $parameters = $this->baseParameters();
+        $parameters['#sourcePrivateKey'] = 'private-key';
+
+        $this->buildConfig($parameters);
+    }
+
+    public function testGroupStrategyRequiresName(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage(
+            'When "replicationStrategy" is "group", "replicationGroup.name" must be set.',
+        );
+
+        $parameters = $this->baseParameters();
+        $parameters['replicationStrategy'] = 'group';
+        $parameters['replicationGroup'] = [
+            'databases' => ['SAPI_1234'],
+        ];
+
+        $this->buildConfig($parameters);
+    }
+
+    public function testGroupStrategyRequiresDatabases(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage(
+            'When "replicationStrategy" is "group", "replicationGroup.databases" must not be empty.',
+        );
+
+        $parameters = $this->baseParameters();
+        $parameters['replicationStrategy'] = 'group';
+        $parameters['replicationGroup'] = [
+            'name' => 'MIGRATE_RG_1234',
+        ];
+
+        $this->buildConfig($parameters);
+    }
+
+    public function testValidGroupStrategy(): void
+    {
+        $parameters = $this->baseParameters();
+        $parameters['replicationStrategy'] = 'group';
+        $parameters['replicationGroup'] = [
+            'name' => 'MIGRATE_RG_1234',
+            'databases' => ['SAPI_1234', 'SAPI_5678'],
+        ];
+
+        $config = $this->buildConfig($parameters);
+
+        self::assertSame('group', $config->getParameters()['replicationStrategy']);
+        self::assertSame('MIGRATE_RG_1234', $config->getParameters()['replicationGroup']['name']);
+        self::assertSame(
+            ['SAPI_1234', 'SAPI_5678'],
+            $config->getParameters()['replicationGroup']['databases'],
+        );
+    }
+}

--- a/tests/phpunit/ReplicationGroupTest.php
+++ b/tests/phpunit/ReplicationGroupTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\AppProjectMigrateLargeTables\Tests;
+
+use Keboola\AppProjectMigrateLargeTables\Strategy\ReplicationGroup;
+use PHPUnit\Framework\TestCase;
+
+class ReplicationGroupTest extends TestCase
+{
+    public function testCreatePrimarySql(): void
+    {
+        $group = new ReplicationGroup('MIGRATE_RG_1234', ['SAPI_1234', 'SAPI_5678']);
+
+        $sql = $group->createPrimarySql('MYORG.TARGETACCT');
+
+        self::assertSame(
+            'CREATE REPLICATION GROUP "MIGRATE_RG_1234" '
+            . 'OBJECT_TYPES = DATABASES '
+            . 'ALLOWED_DATABASES = "SAPI_1234", "SAPI_5678" '
+            . 'ALLOWED_ACCOUNTS = MYORG.TARGETACCT;',
+            $sql,
+        );
+    }
+
+    public function testCreateSecondarySql(): void
+    {
+        $group = new ReplicationGroup('MIGRATE_RG_1234', ['SAPI_1234']);
+
+        $sql = $group->createSecondarySql('SRCORG.SRCACCT');
+
+        self::assertSame(
+            'CREATE REPLICATION GROUP "MIGRATE_RG_1234" '
+            . 'AS REPLICA OF SRCORG.SRCACCT."MIGRATE_RG_1234";',
+            $sql,
+        );
+    }
+
+    public function testRefreshSql(): void
+    {
+        $group = new ReplicationGroup('MIGRATE_RG_1234', ['SAPI_1234']);
+
+        self::assertSame(
+            'ALTER REPLICATION GROUP "MIGRATE_RG_1234" REFRESH;',
+            $group->refreshSql(),
+        );
+    }
+
+    public function testDropSql(): void
+    {
+        $group = new ReplicationGroup('MIGRATE_RG_1234', ['SAPI_1234']);
+
+        self::assertSame(
+            'DROP REPLICATION GROUP IF EXISTS "MIGRATE_RG_1234";',
+            $group->dropSql(),
+        );
+    }
+
+    public function testGetDatabases(): void
+    {
+        $group = new ReplicationGroup('RG', ['A', 'B']);
+        self::assertSame(['A', 'B'], $group->getDatabases());
+    }
+
+    public function testAlterAllowedDatabasesSql(): void
+    {
+        $group = new ReplicationGroup('RG', ['A', 'B']);
+        self::assertSame(
+            'ALTER REPLICATION GROUP "RG" SET ALLOWED_DATABASES = "A", "B";',
+            $group->alterAllowedDatabasesSql(),
+        );
+    }
+
+    public function testAlterAllowedAccountsSql(): void
+    {
+        $group = new ReplicationGroup('RG', ['A']);
+        self::assertSame(
+            'ALTER REPLICATION GROUP "RG" SET ALLOWED_ACCOUNTS = ORG.ACCT;',
+            $group->alterAllowedAccountsSql('ORG.ACCT'),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds an optional Snowflake **Replication Group** strategy to the `database` mode of `keboola.app-project-migrate-large-tables`. Standalone per-database replication remains the default and is unchanged, so existing configurations keep working.

## Why

Standalone per-database replication materializes cross-database zero-copy clones on the secondary account, inflating storage usage. Snowflake support recommends using a Replication Group that includes all related databases together, which preserves cross-database clone relationships and avoids physically materializing the shared micro-partitions. See https://docs.snowflake.com/en/user-guide/database-replication-considerations

## What changed

- New `replicationStrategy` config parameter (enum `standalone` [default] / `group`) in both the `run` action and the `createReplications` sync action.
- New `replicationGroup` config node:
  - `run` action: **only `name`**.
  - `createReplications` sync action: `name` + `databases` (explicit member list, used for `ALLOWED_DATABASES`).
- The source `org_name.account_name` identifier is **derived automatically** from `sourceKbcUrl` via the predefined stack mapping in `src/Config.php` (a new `accountIdentifier` per stack) — the same mechanism standalone uses for `region.account`. It is **not** a config parameter.
- **Primary side** (`DatabaseReplication` / `createReplications`): when `group`, issues `CREATE REPLICATION GROUP ... ALLOWED_DATABASES=... ALLOWED_ACCOUNTS=<targetOrg.targetAccount>`. Target `org.account` is read from the live target connection via `CURRENT_ORGANIZATION_NAME()` / `CURRENT_ACCOUNT_NAME()`. Falls back to `ALTER` on "already exists".
- **Secondary side** (`DatabaseMigrate`): when `group`, issues `CREATE REPLICATION GROUP ... AS REPLICA OF <sourceOrg.sourceAccount.rg>` + `REFRESH`, then migrates the **single project database** it resolves from `projectId` (the group replicates members under their original source names; the database list is not needed on the run action), and conditionally drops the group.
- **Same-prefix restriction:** `group` is rejected when the source and target stacks share the same `db_prefix`, because group members keep their source names and cannot be renamed, so the replicated database would collide with a destination-owned one. Use `standalone` for such stack pairs.
- **`replica.drop` defaults to `false` in group mode:** the group is shared by all per-project runs migrating its member databases, so an individual run does not tear it down. The orchestrator drops it once after all databases are migrated (still overridable via `replica.drop`).
- New `ReplicationGroup` SQL builder helper (CREATE / ALTER / REFRESH / DROP), with unit tests.
- `Connection` gains cached `getOrgName()` / `getAccountName()` helpers.
- Documentation updated (`README.md`, `overview.md`, `how-it-works.md`, `configuration.md`) and `CLAUDE.md` key-files table.

## Design decisions

- Group membership is an **explicit list** from config (on the `createReplications` side only) — no auto-discovery.
- The source `org.account` identifier is **derived from the predefined stack map** via `sourceKbcUrl` (no live source connection on the run action); the group name comes from config and the orchestrator (`app-project-migrate`) uses the same name on both sides.
- The run action migrates a **single project database**; the member database list lives only on the primary side.
- `group` is rejected for stack pairs sharing a `db_prefix` (collision protection).
- `replica.drop` defaults to `false` in `group` mode; teardown is owned by the orchestrator.
- All replication-group SQL runs as `ACCOUNTADMIN`.

## Follow-up

Orchestrator-side integration (selecting/driving the group strategy, group teardown) is tracked in AJDA-2881.

## Backward compatibility

`replicationStrategy` defaults to `standalone`; the standalone code path is behaviorally unchanged. Existing configs are unaffected.

## Testing

- `composer phpcs`, `composer phpstan` (level max), `composer tests-phpunit` — all pass (62 tests, 140 assertions).
- New unit tests for `ReplicationGroup` SQL builder, `CreateReplicationsConfigDefinition`, source-account derivation, same-prefix restriction, and the `replica.drop` default.
- `tests-datadir` not run locally (requires live Snowflake / Storage API credentials); standalone path unchanged.

Closes AJDA-2603.
